### PR TITLE
docs: plan the Black-Litterman allocation engine and model roster

### DIFF
--- a/docs/adr/0001-black-litterman-model-conventions.md
+++ b/docs/adr/0001-black-litterman-model-conventions.md
@@ -1,0 +1,474 @@
+# ADR-0001 — Black-Litterman model conventions
+
+|            |                                                                                             |
+| ---------- | ------------------------------------------------------------------------------------------- |
+| **Status** | **Proposed — requires domain sign-off before Phase 1 begins**                               |
+| Date       | 2026-08-12                                                                                  |
+| Supersedes | conflicting statements in four spec documents (see [§7](#7-spec-errata-issued-by-this-adr)) |
+| Related    | [Implementation plan](../black-litterman-implementation-plan.md)                            |
+
+## Context
+
+The Black-Litterman specification is 45 documents deep and mathematically
+detailed, but it is **self-contradictory in three places and silent in three
+more**. Every one of these gaps changes the numbers a solver produces. A solver
+built before they are settled would produce plausible output that cannot be
+validated against the literature, and the golden vectors would end up chosen to
+match whatever was built.
+
+This ADR resolves all six. Decisions D1, D2 and D3 are modelling judgements and
+are the ones a domain reviewer should scrutinise; D4, D5 and D6 are engineering
+policy.
+
+**Nothing here is implemented.** This document exists so that Phase 1 starts
+from a decided contract.
+
+---
+
+## D1 — View uncertainty (Ω) calibration
+
+### Problem
+
+Four formulas appear across the specs for the same quantity, giving four
+different answers:
+
+| Source                                  | Formula                          | Ω at c=1           | Ω at c=0 |
+| --------------------------------------- | -------------------------------- | ------------------ | -------- |
+| `black-litterman-model.md:158`          | Ω = diag(P(τΣ)Pᵀ)                | n/a (no c)         | n/a      |
+| `black-litterman-model.md:161`          | Ω_ii = (1/c_i)(PΣPᵀ)\_ii         | **(PΣPᵀ)\_ii ≠ 0** | ÷0       |
+| `black-litterman-views.md:148`          | Ω_ii = (PΣPᵀ)\_ii·(1−c_i)/c_i    | 0                  | ÷0       |
+| `black-litterman-implementation.md:226` | Ω_ii = (P(τΣ)Pᵀ)\_ii·(1−c_i)/c_i | 0                  | ÷0       |
+
+`black-litterman-model.md:161` is **provably wrong against the spec's own
+validation requirements**: at c=1 it leaves Ω non-zero, so the view does not
+bind and `Pμ_BL ≠ Q`, contradicting the sanity check at
+`black-litterman-validation.md:36`.
+
+### Decision
+
+Implement four named methods behind an explicit `OmegaCalibration` selector.
+Default `ProportionalToPrior`.
+
+**1. `ProportionalToPrior` (default)**
+
+```
+Ω = diag( P (τΣ) Pᵀ )
+```
+
+He & Litterman's original. Carries no confidence input — every view is held at
+the uncertainty the prior itself implies for that combination of assets. This is
+the default because it is the form the published golden vectors are computed
+under; changing the default would make the literature reproduction fail for a
+reason that is not a bug.
+
+**2. `ConfidenceScaled`**
+
+```
+Ω_ii = ( P (τΣ) Pᵀ )_ii · (1 − c_i) / c_i        c_i ∈ (0, 1]
+```
+
+`black-litterman-implementation.md:226` is adopted as the confidence-bearing
+form. It satisfies both required limits: c→1 gives Ω→0 (view binds exactly,
+requirement B2) and c→0 gives Ω→∞ (equilibrium prevails, requirement B4).
+
+Endpoint handling — **not** clamping to ε:
+
+- **c_i = 0 ⇒ drop the view's row from P and Q entirely.** This is exactly
+  equivalent to the Ω→∞ limit and is numerically clean, where clamping is
+  neither. A view with zero confidence is a view the user has switched off.
+- **c_i = 1 ⇒ Ω_ii = 0**, which is well-posed in E3 and undefined in E2
+  (Ω⁻¹). See D6: E3 is the production path partly for this reason.
+- All views at c=0 ⇒ k=0 ⇒ μ_BL = Π. Consistent with B1.
+
+**3. `IdzorekTilt`** (Phase 4)
+
+Idzorek's confidence method: c_i is the fraction of the way from the prior
+weights to the 100%-confidence weights that view i should actually move the
+portfolio.
+
+```
+w₁₀₀,ᵢ  = optimal weights with view i at Ω_ii = 0, others unchanged
+w_target,ᵢ = w_mkt + c_i · (w₁₀₀,ᵢ − w_mkt)
+solve for Ω_ii  such that  w(Ω_ii) = w_target,ᵢ
+```
+
+**Implement by 1-D root-finding (Brent on log Ω_ii), not by Idzorek's printed
+closed-form approximation.** The weight displacement is monotone in Ω_ii, so
+bracketing convergence is guaranteed. This choice matters for two reasons: the
+closed form is an approximation whose errata are part of why Walters (2014) is in
+the spec's own reference list, and root-finding is **self-validating** — the test
+is simply whether the resulting weights hit the target tilt, with no dependence
+on a printed table.
+
+**4. `Explicit`**
+
+Caller supplies `InvestorViewDto.ViewVariance` per view. Escape hatch, and the
+only method that permits a full non-diagonal Ω later. Required for backtests that
+calibrate Ω from historical forecast error (`black-litterman-views.md:131`).
+
+### Consequence worth knowing: τ cancels
+
+Under both `ProportionalToPrior` and `ConfidenceScaled`, Ω is proportional to τ.
+Substituting into E3:
+
+```
+τΣPᵀ [ τPΣPᵀ + τK ]⁻¹ (Q − PΠ)  =  ΣPᵀ [ PΣPᵀ + K ]⁻¹ (Q − PΠ)
+```
+
+where `K = diag(PΣPᵀ)` or `diag((PΣPᵀ)_ii(1−c)/c)`. **τ cancels exactly, so
+μ_BL is invariant to τ under both default methods.** τ still scales the
+posterior covariance: `M = τ[Σ⁻¹ + Pᵀ(K)⁻¹P]⁻¹`, so `M ∝ τ`.
+
+Two consequences:
+
+- τ is close to a nuisance parameter in this design. The team should not spend
+  calibration effort on it, and a test that varies τ and expects μ_BL to move
+  would be asserting the wrong thing.
+- Under `Explicit`, Ω does **not** scale with τ and this cancellation does not
+  hold. τ matters there.
+
+Both facts become tests (T1.12).
+
+### Rejected
+
+`black-litterman-model.md:161` — contradicts requirement B2. Issued as errata.
+
+---
+
+## D2 — Posterior covariance, and the optimizer's risk matrix
+
+### Problem
+
+`BlackLittermanResultDto.PosteriorCovariance` exists. No spec document defines
+it; `BlackLitterman-Overview.md:42` names it and stops. Two conventions are in
+circulation and they differ by Σ, which is not a small correction.
+
+Separately, E4 (`black-litterman-model.md:172`) computes weights with **Σ**,
+while the He & Litterman derivation that the golden vectors come from uses the
+posterior. These are different portfolios.
+
+### Decision
+
+**Return `Σ_p = Σ + M`** as `PosteriorCovariance`, where
+`M = [(τΣ)⁻¹ + PᵀΩ⁻¹P]⁻¹`.
+
+M alone is the covariance of the _estimate of the mean_; Σ + M is the covariance
+of _returns_, which is what the field name and its consumer (a risk display) mean.
+
+**Optimizer risk matrix is an explicit option, defaulting to Σ** (`RiskMatrixChoice.PriorCovariance`),
+with `PosteriorCovariance` available for literature reproduction. The resolved
+choice is echoed in the result diagnostics.
+
+### Rationale, and the trade-off a reviewer should weigh
+
+The default follows E4 as written, and it is the only choice under which
+requirement B3 holds **exactly**:
+
+```
+w* = (λΣ)⁻¹ Π = (λΣ)⁻¹ (λ Σ w_mkt) = w_mkt        exact, to machine precision
+```
+
+That exactness is worth a lot — B3 is the cheapest strong correctness test in
+the suite, and it degrades under Σ_p. In the no-view case M = τΣ, so
+Σ_p = (1+τ)Σ and:
+
+```
+w* = (λΣ_p)⁻¹ Π = w_mkt / (1 + τ)
+```
+
+Under Σ_p, B3 holds only up to that scale factor — exactly after budget
+normalization. This is the familiar result that unconstrained BL weights come out
+scaled by 1/(1+τ) against the market book.
+
+**This is the decision in this ADR most likely to be overturned, and it is a
+genuine modelling judgement.** The Bayesian-consistent argument favours Σ_p: if
+you are uncertain about μ, that uncertainty belongs in the risk term. The
+argument for Σ is that it is what the spec says, what most practitioner
+implementations do, and what makes B3 exact. Because the choice is exposed as an
+option and echoed in diagnostics, flipping the default later is a one-line change
+plus a golden-vector re-baseline — not a rewrite.
+
+**Every golden-vector fixture states which convention it assumes in its header.**
+Most failures to reproduce this model are convention mismatches, not arithmetic
+errors.
+
+---
+
+## D3 — Units and return basis
+
+### Problem
+
+`black-litterman-implementation.md:109-120` annualizes — monthly excess returns,
+`cov × 12`. Nothing in `BlackLittermanInputDto` declares the frequency or
+annualization state of `CovarianceMatrix`, `EquilibriumReturns`,
+`RiskFreeRate`, or the views' `ExpectedReturn`.
+
+A monthly Σ combined with annual views produces a wrong answer with no error, no
+warning, and an entirely plausible shape. **This is the single most likely source
+of a silently incorrect production result.**
+
+### Decision
+
+Add one required field:
+
+```csharp
+public enum ReturnBasis { Daily, Weekly, Monthly, Quarterly, Annual }
+```
+
+Meaning: _every rate and every covariance entry in this payload is expressed per
+this period._ A single enum rather than a frequency plus an `IsAnnualized` flag,
+because two fields admit contradictory combinations and one does not.
+
+Rules:
+
+1. `ReturnBasis` is **required**. There is no default — a default here is a
+   silent assumption, which is the failure mode being eliminated.
+2. **The engine does not convert.** It computes in the declared basis and echoes
+   it on the result. Automatic conversion invites a compounding error that is
+   invisible at the boundary.
+3. `RiskFreeRate` and every view's `ExpectedReturn` are on the same basis. The
+   validator cannot verify this — it is a documented caller contract, reinforced
+   by a plausibility warning (see D6).
+
+### Excess vs. total return, and what `RiskFreeRate` is for
+
+**The engine works entirely in excess-return space.** Π, Q, and μ_BL are all
+excess returns; Σ is the covariance of excess returns. This is consistent
+throughout the specs.
+
+`RiskFreeRate` therefore has no role in the core computation. It is used only to
+report total expected return alongside excess (`total = excess + rf`) in the
+result metrics. Documented as such, so nobody later "fixes" the Sharpe ratio by
+subtracting it twice — with excess returns, `Sharpe = wᵀμ / √(wᵀΣw)` is already
+correct with no rf term.
+
+---
+
+## D4 — Equilibrium returns: input or derived
+
+### Problem
+
+`EquilibriumReturns` is an input field, but E1 derives Π from λ, Σ and w_mkt.
+When both are present and disagree, behaviour is undefined.
+
+### Decision
+
+1. `EquilibriumReturns` non-empty ⇒ **use it verbatim**, skip E1.
+2. Empty ⇒ derive via `Π = λΣw_mkt`.
+3. When both are available, compute E1 anyway and compare. If
+   `‖Π_supplied − Π_derived‖₂ / ‖Π_derived‖₂ > 0.10`, emit a diagnostic warning.
+   Do not fail — a caller may legitimately supply a Π from a different model —
+   but a caller passing a stale vector should find out.
+4. `Diagnostics.EquilibriumSource ∈ { Supplied, Derived }`, always populated.
+
+Rationale: silent precedence is the problem. Explicit precedence plus a
+divergence warning keeps both use cases open while making the choice visible in
+the audit record that `BlackLitterman-Reference.md:22` requires.
+
+---
+
+## D5 — Definitions for the undefined result fields
+
+### Problem
+
+`TiltMagnitude`, `ViewImpactDto.ImpactScore`, `ImpliedConfidenceLevel`,
+`ImpliedRiskAversion`, `ReturnContribution` and `RiskContribution` appear in the
+result DTO. **None of the six is defined anywhere in the 45 specification
+documents** — verified by
+grepping both trees for `tilt`, `implied confidence`, `view impact` and
+`attribution`. They are UI-shaped fields invented ahead of the mathematics.
+Without definitions the engine emits a number for each and the number means
+nothing.
+
+### Decision
+
+All attribution is **leave-one-out**, computed with the _same optimizer and the
+same constraints_ as the main solve. Attribution computed under a different
+constraint set is incoherent with the portfolio it claims to explain.
+
+Notation: `w*` = final weights; `w₍₋ᵢ₎` = weights with view i removed;
+`w₁₀₀,ᵢ` = weights with view i at Ω_ii = 0 and all others unchanged;
+`Δᵢ = w* − w₍₋ᵢ₎`; `dᵢ = Q_i − P_iΠ` (how much more bullish view i is than
+equilibrium on its asset combination).
+
+**`TiltMagnitude`**
+
+```
+TiltMagnitude = ‖ w* − w_mkt ‖₁
+```
+
+Sum of absolute weight deviations from the neutral book. Note for the UI: this is
+**twice** one-way turnover when both books are fully invested. Label it
+"total absolute tilt", not "turnover".
+
+**`ViewImpactDto.ImpactScore` ∈ [−1, 1]**
+
+```
+ImpactScoreᵢ = sign( dᵢ · (P_i Δᵢ) ) · ‖Δᵢ‖₁ / max(‖w* − w_mkt‖₁, ε)     clamped to [−1,1]
+```
+
+Magnitude is view i's share of the total tilt. Sign is positive when the
+portfolio moved _in the direction the view argued for_ and negative when the
+view was overruled by the other views and the constraints — which is genuinely
+informative and is the case a user most wants surfaced.
+
+**These scores do not sum to 1.** Views interact; leave-one-out effects are not
+additive. This must be stated in the API documentation, because the obvious UI
+for a set of scores is a pie chart and a pie chart here would be a lie.
+
+**`ImpliedConfidenceLevel`** — keyed by **`ViewId`** (the key set is unstated in
+the DTO; this fixes it):
+
+```
+ImpliedConfidenceᵢ = ‖ w* − w₍₋ᵢ₎ ‖₁ / max(‖ w₁₀₀,ᵢ − w₍₋ᵢ₎ ‖₁, ε)     clamped to [0,1]
+```
+
+Idzorek's implied confidence, generalized to multiple views: the tilt view i
+actually achieved as a fraction of the tilt it would achieve at full confidence.
+Under `IdzorekTilt` this should return approximately the `Confidence` that was
+input — **which makes it a self-consistency test** (T2.5).
+
+**`ReturnContribution` / `RiskContribution`**
+
+```
+ReturnContributionᵢ = w*ᵀ μ_BL      − w₍₋ᵢ₎ᵀ μ₍₋ᵢ₎
+RiskContributionᵢ   = √(w*ᵀ Σ w*)   − √(w₍₋ᵢ₎ᵀ Σ w₍₋ᵢ₎)
+```
+
+Deltas, not shares. Also non-additive; documented as such.
+
+**`ImpliedRiskAversion`** — _missed in the first pass of this ADR; it is a sixth
+undefined result field, not a fifth._
+
+```
+λ_implied = ( w_mktᵀ Π ) / ( w_mktᵀ Σ w_mkt )
+```
+
+This is not an invention: it is exactly the spec's own calibration formula
+`λ = (E(R_m) − r_f) / σ_m²` (`black-litterman-model.md:138`) expressed in
+quantities the engine already holds — `w_mktᵀΠ` **is** the market excess return
+and `w_mktᵀΣw_mkt` **is** the market variance.
+
+It has a useful dual role:
+
+- When Π is **derived** (E1), it returns the input λ _exactly_, since
+  `w_mktᵀ(λΣw_mkt) / w_mktᵀΣw_mkt = λ`. That makes it a free self-consistency
+  check on the whole equilibrium path — test T1.17.
+- When Π is **supplied** (D4), it reports what λ the caller's equilibrium vector
+  actually implies, which is precisely the diagnostic a caller passing an
+  external Π wants.
+
+**`TradeRecommendations`**
+
+```
+TradeRecommendation[a] = w*[a] − CurrentHoldings[a]     where |·| ≥ MinimumTradeSize
+```
+
+If `CurrentHoldings` is empty, `TradeRecommendations` is **empty** and a
+diagnostic says why. Emitting `w*` as if it were a trade list would imply a full
+liquidate-and-rebuild that the caller never described.
+
+### Cost
+
+`2k + 1` solves total (k for leave-one-out, k for the 100%-confidence variants,
+1 for the main solve). k is typically 1–5. Negligible, including with the QP in
+the loop.
+
+---
+
+## D6 — Numerical policy
+
+### Decision
+
+**Production posterior path is E3** (the covariance form,
+`black-litterman-model.md:130`):
+
+```
+μ_BL = Π + τΣPᵀ [ τPΣPᵀ + Ω ]⁻¹ (Q − PΠ)
+```
+
+It inverts a k×k matrix (k ≤ ~5) rather than two n×n matrices, and it is
+well-posed at Ω = 0, which E2 is not. **E2 is implemented anyway and asserted to
+agree to 1e-10** — two independent derivations of the same quantity is the
+cheapest strong correctness signal available on this problem.
+
+**Never form an explicit inverse.** Every `⁻¹` in this ADR is implemented as
+`Cholesky.Solve`. It is faster, more accurate, and Cholesky _failing_ is the
+positive-definiteness check.
+
+**PSD repair.** `black-litterman-implementation.md:367` proposes clipping
+eigenvalues at an absolute `1e-6`. This is rejected as scale-dependent: for daily
+return covariances, variances are order 1e-4 and an absolute 1e-6 floor is a
+material distortion rather than a repair. Use a **relative** floor:
+
+```
+λᵢ ← max( λᵢ , 1e-10 · λ_max )
+```
+
+Reject outright if `λ_min < −1e-8 · λ_max` — that is not a rounding artifact but
+a genuinely indefinite input, and repairing it silently would be fabricating a
+covariance the caller did not supply. Set `Diagnostics.PsdRepairApplied` whenever
+any eigenvalue is clipped.
+
+**Conditioning.** Warn at `κ(Σ) > 1e10`; reject at `κ(Σ) > 1e14`. Condition
+number is always reported in diagnostics.
+
+**Thresholds are configurable but have defined defaults.** The defaults above are
+policy, not physics; they are named constants, not literals scattered through the
+solver.
+
+**Plausibility warnings** (diagnostics only, never failures) — these catch the
+D3 unit error, which no validator can detect structurally:
+
+- any `|Π_i| > 1.0` on an `Annual` basis, or `> 0.2` on `Monthly`
+- any diagonal `Σ_ii` implying annualized volatility `> 300%`
+- `Σ` diagonal spanning more than 6 orders of magnitude
+
+**decimal/double boundary** — full rules in the implementation plan §3.2.
+Summary: `double` inside, `decimal` at the wire, one conversion seam, outbound
+rounding at scale 10 with `MidpointRounding.ToEven`, weights renormalized after
+rounding so they sum to exactly `1.0m`, and `double.IsFinite` guards so no
+non-finite value is ever converted.
+
+---
+
+## 7. Spec errata issued by this ADR
+
+Pointer notes are added in place to the affected documents. No spec content is
+deleted — the errata note names this ADR and states what supersedes what.
+
+| Document                            | Location                                          | Errata                                               |
+| ----------------------------------- | ------------------------------------------------- | ---------------------------------------------------- |
+| `black-litterman-model.md`          | §Parameter Calibration → View Uncertainty (~:153) | option 2 is withdrawn — contradicts validation.md:36 |
+| `black-litterman-model.md`          | §Optimal Portfolio Weights (~:168)                | risk matrix is an explicit choice; see D2            |
+| `black-litterman-views.md`          | §Confidence Scaling (~:139)                       | superseded by D1 `ConfidenceScaled` (τ included)     |
+| `black-litterman-implementation.md` | `calibrate_omega` (~:204)                         | adopted as canonical; endpoint handling added        |
+| `black-litterman-implementation.md` | `ensure_positive_definite` (~:365)                | absolute eigenvalue floor replaced by relative       |
+
+---
+
+## Consequences
+
+**Positive.** Phase 1 starts from a decided contract. Four new exact invariants
+fall out of the analysis and become tests: τ-invariance of μ_BL under both
+default Ω methods, `M ∝ τ`, `Σ_p = (1+τ)Σ` with no views, and
+`w* = w_mkt/(1+τ)` under the Σ_p risk matrix with no views. Each is exact and
+cheap, and none depends on any literature table.
+
+**Negative.** Three input fields are added and `BlackLittermanConstraintDto.Type`
+changes from `string` to an enum. This is safe **only because nothing consumes
+these DTOs yet** — verified: `PortfolioMetricsDto`, `BlackLittermanConstraintDto`,
+`InvestorViewDto` and `ViewImpactDto` have no references outside their own
+declaration file. **That window closes the moment the API ships**, which is an
+argument for landing the DTO changes early rather than after Phase 7.
+
+**Open.** D2's default is the decision most likely to be revisited; it is
+deliberately structured as a flipped default plus a golden re-baseline rather
+than a rewrite.
+
+## Sign-off required
+
+- [ ] Ω default and the withdrawal of `model.md:161` (D1)
+- [ ] `Σ` vs `Σ_p` as the optimizer risk matrix (D2) — _the one to argue about_
+- [ ] Excess-return space and `RiskFreeRate`'s reporting-only role (D3)
+- [ ] Attribution definitions, and that the scores are non-additive (D5)

--- a/docs/adr/0002-numeric-core-runtime.md
+++ b/docs/adr/0002-numeric-core-runtime.md
@@ -1,0 +1,251 @@
+# ADR-0002 — Numeric core runtime: Rust native library via P/Invoke
+
+|             |                                                                                                                           |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **Status**  | **Accepted** (runtime choice), **Proposed** (FFI design details below)                                                    |
+| Date        | 2026-08-12                                                                                                                |
+| Decision by | Repository owner, this session                                                                                            |
+| Related     | [ADR-0001](./0001-black-litterman-model-conventions.md), [Implementation plan](../black-litterman-implementation-plan.md) |
+
+## Context
+
+An earlier draft of the implementation plan assumed the Black-Litterman solver
+would be written in C# against MathNet.Numerics, on the reasoning that the
+platform is a .NET solution and in-process is simplest.
+
+That reasoning does not survive contact with three facts:
+
+1. **.NET has no maintained quadratic programming solver.** Verified on
+   nuget.org: `Accord.Math` is archived at 3.8.0, `Google.OrTools` 9.15's
+   continuous solvers are LP, and alglib's free edition is GPL — incompatible
+   with a commercial product. The C# plan therefore required hand-rolling
+   Goldfarb–Idnani: ~200 lines of subtle numerical code the team would own
+   permanently, written only because the ecosystem lacked an alternative.
+2. **The test oracle was going to be a different language anyway.** The
+   differential-testing tier specifies numpy/PyPortfolioOpt as the reference.
+   Having the reference implementation be more trustworthy than the
+   implementation under test is an argument about which one should be shipping.
+3. **Phase 9 is already written in another language.** The ML shrinkage specs
+   (`bl-ai-shrinkage-loss-kl-gaussian.md`, `bl-ai-shrinkage-loss-spectral.md`)
+   are TensorFlow, not language-neutral pseudocode. No plan that assumes C# for
+   that phase is credible.
+
+## Decision
+
+**The numeric core is a Rust library, consumed from .NET as a native library via
+P/Invoke.** C# retains DTO contracts, validation, CQRS orchestration, and the
+HTTP surface; it performs no numerical computation.
+
+```
+crates/vv-portfolio-core/    pure Rust: BL math, optimizer, attribution. No FFI, no C ABI.
+crates/vv-portfolio-ffi/     cdylib: thin C ABI shim. Serialization + panic containment only.
+src/vv.Analytics/     C# P/Invoke bindings, SafeHandle, IBlackLittermanEngine impl.
+```
+
+`vv-portfolio-core` knows nothing about FFI and is testable with `cargo test` alone.
+That separation is what keeps the mathematics debuggable.
+
+**On the name.** An earlier draft called this `vv-bl-core`. That boxes it in: this
+repository already carries specifications for `MarkowitzModel.md`,
+`MichaudResampling.md`, `EqualRiskContribution.md` and `portfolio-optimization.md`,
+every one of which needs the same optimizer, the same covariance estimators, and
+the same matrix guards. Black-Litterman is a `black_litterman` module inside a
+portfolio-mathematics crate, not the crate itself. Renaming later means churning
+the FFI package name, the NuGet id, and every downstream reference — cheap now,
+expensive after Phase 7. The C ABI entry point stays `vv_bl_solve` precisely so
+that a future `vv_mvo_solve` can sit beside it.
+
+### Dependencies
+
+Verified on crates.io, 2026-08-12. Local toolchain confirmed: cargo/rustc 1.97.1.
+
+| Crate                  | Version | Licence        | Downloads | Role                                                  |
+| ---------------------- | ------- | -------------- | --------- | ----------------------------------------------------- |
+| `nalgebra`             | 0.35.0  | Apache-2.0     | 83.1M     | dense LA: Cholesky, symmetric eigendecomposition, SVD |
+| `clarabel`             | 0.11.1  | Apache-2.0     | 1.67M     | interior-point conic solver — **the QP**              |
+| `serde` / `serde_json` | —       | MIT/Apache-2.0 | —         | FFI payload                                           |
+
+**Every dependency is permissive-licensed.** On the .NET side the only mature QP
+option was GPL; that constraint disappears here. This is a genuine and slightly
+unexpected advantage of the Rust route.
+
+`clarabel` is the reference implementation of that solver — its Python and Julia
+packages are wrappers over this crate — so using it from Rust removes a layer
+rather than adding one. `faer` 0.24.4 (MIT) was considered for the linear algebra
+and is faster, but `nalgebra`'s maturity and documentation matter more than speed
+at n ≤ 50, where a full solve is sub-millisecond either way.
+
+### QP formulation for Clarabel
+
+Clarabel takes `min ½xᵀPx + qᵀx  s.t.  Ax + s = b, s ∈ K`. The portfolio problem
+maps cleanly:
+
+```
+maximize   wᵀμ − (λ/2) wᵀΣw
+⟺ minimize ½ wᵀ(λΣ) w − μᵀw          so  P = λΣ,  q = −μ
+
+budget   Σw = 1              →  ZeroCone block
+L ≤ Aw ≤ U                   →  two NonnegativeCone blocks
+box 0 ≤ w ≤ 1                →  special case of the above
+```
+
+**Spike required before Phase 5 commits to this**: confirm Clarabel 0.11's exact
+Rust API surface and cone-construction ergonomics against a worked example. The
+version and licence are verified; the API shape is not.
+
+## FFI design
+
+This is where projects of this shape fail, so the rules are explicit.
+
+### One call per solve, self-describing payload
+
+The C ABI is deliberately narrow — **not** a chatty surface passing matrix
+pointers:
+
+```c
+int32_t vv_bl_solve(const uint8_t* req, size_t req_len,
+                    uint8_t** out, size_t* out_len);
+void    vv_bl_free(uint8_t* ptr, size_t len);
+int32_t vv_bl_abi_version(void);
+```
+
+Request and response are JSON (`serde` ⇄ `System.Text.Json`).
+
+Rationale: at n ≤ 50 the covariance matrix is ~20 KB and there is **one crossing
+per HTTP request**, so serialization cost is irrelevant next to correctness.
+Marshalling nested variable-length arrays across P/Invoke means manual
+`[StructLayout]`, pinning, and lifetime management — precisely the class of bug
+that produces silent memory corruption rather than a clean failure. JSON is
+self-describing and versionable, and `vv_bl_abi_version` lets C# refuse a
+mismatched binary at startup instead of misreading it.
+
+If profiling ever shows this matters — it will not at this size — a flat
+`f64` buffer layout can replace JSON behind the same wrapper.
+
+**Critically, the entire solve happens Rust-side, including the `2k+1`
+attribution solves from [ADR-0001 §D5](./0001-black-litterman-model-conventions.md#d5--definitions-for-the-undefined-result-fields).**
+Attribution must use the same optimizer and constraints as the main solve, so a
+per-solve boundary crossing would be both slow and incoherent.
+
+### Memory ownership
+
+Rust allocates the response; **Rust frees it.** C# wraps the pointer in a
+`SafeHandle` subclass so release happens even on exception.
+
+**Never free Rust-allocated memory with `Marshal.FreeHGlobal`** — different
+allocator, immediate heap corruption. This is stated here because it is the
+mistake that gets made.
+
+### Panics must not cross the boundary
+
+Unwinding across an FFI boundary is undefined behaviour. Every `extern "C"`
+entry point wraps its body in `std::panic::catch_unwind` and converts a panic
+into an error status code. `panic = "abort"` is **rejected** — it would take down
+the API process on a bad input.
+
+### Error handling
+
+Non-zero status code plus a structured error object in the response payload,
+carrying the same diagnostics contract as the success path. No `NaN`, no `Inf`,
+no sentinel values crossing the boundary — [ADR-0001 §D6](./0001-black-litterman-model-conventions.md#d6--numerical-policy) applies at the Rust
+edge, not just the C# one.
+
+### C# binding style
+
+`[LibraryImport]` (source-generated, .NET 7+), not `[DllImport]` — no runtime
+marshalling stubs, AOT-friendly. Requires `partial` methods and
+`AllowUnsafeBlocks`.
+
+## Cross-platform bit-determinism is a hard requirement
+
+`BlackLitterman-Reference.md:22` requires that _"all model inputs and outputs are
+cryptographically signed and auditable."_ That promotes reproducibility from a
+nice-to-have to a **correctness constraint**: if a solve on a Windows developer
+machine and the same solve in a Linux production container differ by one ULP, the
+signature does not verify and the audit trail is worthless.
+
+This is a real risk under ADR-0002 and it is cheap to eliminate _if decided now_
+and expensive to retrofit:
+
+1. **`nalgebra` must stay on its pure-Rust path.** It is deterministic by
+   default, but enabling any BLAS/LAPACK feature delegates to a vendor kernel
+   whose result depends on CPU dispatch and thread count. The BLAS features are
+   **forbidden**, enforced by a CI check on the resolved feature set, not by
+   convention.
+2. **No `-C target-cpu=native`.** It selects different SIMD paths per build
+   machine, which changes summation order and therefore the last bits. Pin an
+   explicit baseline target-feature set per RID.
+3. **Audit `clarabel`'s backend.** It may optionally link an external linear
+   solver; confirm the default is pure Rust and single-threaded, or pin it so.
+   Fold this into the Clarabel API spike already scheduled before Phase 5.
+4. **CI proves it rather than assuming it**: run the golden fixtures on all three
+   RIDs, hash the canonicalized result JSON, assert the hashes are equal. A
+   determinism claim that is not tested is a determinism hope.
+
+Rust helps here — no fast-math by default, and no implicit FMA contraction — but
+none of that survives a BLAS backend or `target-cpu=native`, so the guard rails
+are explicit.
+
+**Consequence for Phase 9.** Any ONNX runtime with SIMD or threading backends is
+a direct threat to this constraint, which raises the bar on that spike
+considerably: a hand-written pure-Rust forward pass is deterministic by
+construction where a general inference runtime is not.
+
+## Build and distribution — the real cost
+
+This is what the Rust choice actually costs, stated plainly.
+
+1. **Cross-platform build matrix.** `win-x64`, `linux-x64`, and `osx-arm64` for
+   local development. If anything deploys to Alpine, `linux-musl-x64` as well —
+   glibc/musl is not interchangeable and the failure mode is a load error at
+   startup.
+2. **Packaged as NuGet with `runtimes/{rid}/native/` layout**, so `dotnet publish`
+   selects the correct binary automatically. Retrofitting this later is worse
+   than doing it now; do not start with loose files copied to output.
+3. **CI**: build Rust on three runners, pack, publish to an internal feed. This
+   is the largest single new piece of infrastructure in the plan.
+4. **Reproducibility**: pin the toolchain with `rust-toolchain.toml`, commit
+   `Cargo.lock`.
+
+## Consequences
+
+**Positive**
+
+- No hand-rolled QP. Clarabel is a maintained interior-point solver with a real
+  user base, replacing ~200 lines the team would otherwise own forever.
+- All dependencies permissive-licensed.
+- `proptest` gives property-based testing of the ADR-0001 invariants (B1–B5,
+  τ-invariance) across generated inputs, which is stronger than hand-written
+  example cases.
+- `cargo miri` can check the core for UB — a class of assurance unavailable in
+  the C# plan.
+- The math is testable with `cargo test`, with no .NET, no DI container, and no
+  HTTP in the loop.
+
+**Negative**
+
+- Debugging across the FFI boundary is worse than in-process. Mitigated by
+  keeping `vv-portfolio-core` FFI-free and reproducing every failure as a `cargo test`.
+- **No off-the-shelf Ledoit–Wolf.** It must be written (~40 lines, closed-form),
+  where sklearn would have supplied it. Acceptable — a closed-form estimator is a
+  very different proposition from a QP solver, and it is validated against
+  sklearn output captured as a fixture.
+- CI and packaging cost, as above.
+- Rust is present in this workspace (phoenix-rooivalk) but is not this team's
+  primary language.
+
+**Phase 9 is not stranded.** The TensorFlow shrinkage models do not run in Rust,
+but they do not need to: train in Python, export ONNX, infer in Rust via the
+`ort` crate (15.4M downloads, MIT/Apache-2.0). Caveat verified and worth
+recording — `ort` currently publishes **release candidates only**, no stable
+version on crates.io as of 2026-08-12. Phase 9 needs its own spike; it is not
+resolved by this ADR.
+
+## Rejected alternatives
+
+| Option                                       | Why not                                                                                                                                                                                       |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **C# + MathNet + hand-rolled QP**            | No maintained .NET QP solver; requires owning Goldfarb–Idnani; Phase 9 not credible in .NET                                                                                                   |
+| **Python sidecar (FastAPI + cvxpy)**         | Strongest ecosystem fit and the recommendation this ADR did not take — rejected in favour of a single deployed artifact with no additional runtime, and no second language runtime to operate |
+| **Hybrid: C# through Phase 3, Python after** | Splits the engine mid-pipeline; attribution needs `2k+1` solves against the same optimizer, so the seam lands in the worst possible place                                                     |
+| **MATLAB**                                   | Not a server runtime. Retains relevance as a _source_ of golden vectors — Meucci's reference code is MATLAB                                                                                   |

--- a/docs/adr/0003-portfolio-model-strategy.md
+++ b/docs/adr/0003-portfolio-model-strategy.md
@@ -1,0 +1,198 @@
+# ADR-0003 — Portfolio model strategy: the deliverable is a comparison harness
+
+|            |                                                                                                                                                         |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Status** | **Proposed** — requires product and domain sign-off                                                                                                     |
+| Date       | 2026-08-12                                                                                                                                              |
+| Related    | [ADR-0001](./0001-black-litterman-model-conventions.md), [ADR-0002](./0002-numeric-core-runtime.md), [ADR-0004](./0004-allocation-model-abstraction.md) |
+| Specs      | [allocation-models.md](../specs/allocation-models.md), [model-verification.md](../specs/model-verification.md)                                          |
+
+## Context
+
+Three documents of planning have gone into building a Black-Litterman solver
+without anyone asking whether a BL solver is the right deliverable. It is worth
+asking, because the answer changes what "good" means.
+
+### The mathematics is commodity
+
+The BL posterior is three matrix operations. He & Litterman (1999) is a 20-page
+paper. PyPortfolioOpt, Riskfolio-Lib and skfolio all ship working, validated
+implementations. Anyone can have a functioning BL engine this afternoon.
+
+So the positioning in `veritasvault-corporate-deck.html` — Black-Litterman as
+core IP and commercial wedge — is a **liability rather than an asset**. Any
+allocator sophisticated enough to ask for Black-Litterman knows it is 1992
+textbook material taught in every quantitative finance programme. Claiming it as
+proprietary costs credibility with precisely the audience it is aimed at.
+
+### The deck already contains the defensible version
+
+`veritasvault-investor-overview.html:582`: _Black-Litterman is the language
+institutional allocators already speak._ That is the real justification —
+**legibility, not differentiation.** BL is table stakes for being taken
+seriously, not a moat.
+
+### Which means the build is justified by auditability, not by mathematics
+
+`pip install pyportfolioopt` yields a solver. It does not yield deterministic,
+cryptographically signed, versioned, independently reproducible allocations,
+which is what `BlackLitterman-Reference.md:22` requires. That is why the
+expensive parts of the implementation plan — cross-RID bit-determinism, input
+hashing, golden validation against published tables — are the _right_ expensive
+parts, and why a thin wrapper around a Python library would not do.
+
+The genuinely defensible work lives in view generation, covariance estimation for
+an asset class where it is hard, and the governance wrapper. Never in the
+posterior formula.
+
+### BL's prior is weaker in digital assets than in equities
+
+Nothing in the 45 specification documents addresses this, and the corporate deck
+has a slide titled _"Black-Litterman, applied to digital assets"_ that needs an
+answer.
+
+BL anchors on `Π = λΣw_mkt` — the market-capitalization portfolio as neutral
+prior. In digital assets:
+
+- market capitalization is contaminated by locked tokens, low float and wash
+  trading, so `w_mkt` is a noisy measurement of a questionable quantity
+- the resulting "neutral" book is dominated by one or two assets
+- returns are fat-tailed and regime-switching, so the Gaussian prior BL assumes
+  is a poorer approximation than in equities
+- histories are short and correlations unstable, so Σ is frequently
+  ill-conditioned — and BL inverts it
+
+**The single most important consequence: a model whose neutral prior is shaky
+should not be the only model.**
+
+### And 1/N is the benchmark nobody has to beat yet
+
+DeMiguel, Garlappi & Uppal (2009) found naive equal weighting frequently beats
+optimized portfolios out of sample, because estimation error swamps optimization
+gains. `equal-weighting.md` exists in the spec tree, so the thought is in the
+building — but as a specification, not as a yardstick. As the implementation plan
+stood before this ADR, **nothing in it could have told anyone whether BL was
+helping.**
+
+## Decision
+
+**The deliverable is a model comparison harness, not a Black-Litterman engine.**
+
+Black-Litterman remains first and its phases are unchanged — legibility and the
+honesty gate both depend on it. What changes is that alternatives become peers in
+the architecture rather than distant roadmap items, and the product surface
+becomes:
+
+> Here is your allocation under Black-Litterman, Equal Risk Contribution,
+> Hierarchical Risk Parity and 1/N, with the differences attributed and each
+> model's assumptions stated.
+
+This is more useful to an allocator, much harder to dismiss, genuinely
+differentiated in a way the posterior formula never will be, and — decisively —
+it makes Black-Litterman **falsifiable**.
+
+### Model roster
+
+Specified in [allocation-models.md](../specs/allocation-models.md). Status column
+is honest: everything here is unbuilt.
+
+| Model                        | Needs μ?   | Needs Σ? | Inverts Σ? | Phase    | Spec today                                                   |
+| ---------------------------- | ---------- | -------- | ---------- | -------- | ------------------------------------------------------------ |
+| Equal weight (1/N)           | no         | no       | no         | 5a       | `equal-weighting.md`                                         |
+| Market-cap weight            | no         | no       | no         | 5a       | BL prior                                                     |
+| Equilibrium (reverse-opt)    | —          | yes      | no         | 2        | `black-litterman-model.md`                                   |
+| Black-Litterman              | produces μ | yes      | yes        | 2–3      | 45 documents                                                 |
+| Mean-variance (MVO)          | yes        | yes      | yes        | 3        | `MarkowitzModel.md`                                          |
+| Minimum variance             | no         | yes      | yes        | 5b       | `risk-based-overview.md:27`                                  |
+| Equal Risk Contribution      | no         | yes      | no†        | 5b       | `EqualRiskContribution.md`                                   |
+| Maximum diversification      | no         | yes      | yes        | 5b       | `risk-based-overview.md:49`                                  |
+| **Hierarchical Risk Parity** | no         | yes      | **no**     | 5b       | **absent** — one passing mention at `bl-ai-reference.md:134` |
+| Michaud resampling           | wraps      | wraps    | wraps      | 6b       | `MichaudResampling.md`                                       |
+| **Entropy pooling**          | produces μ | yes      | yes        | deferred | **absent** — footnote at `black-litterman-views.md:185`      |
+
+† ERC is solved as a convex log-barrier problem, not by inverting Σ.
+
+**HRP is the most valuable addition and is effectively absent from the spec
+tree.** It never inverts the covariance matrix — decisive when Σ is
+ill-conditioned or when n > T, which is the normal condition for digital assets.
+It requires no expected returns at all. It is also the cheapest model on the list
+to build: clustering plus recursive bisection, no solver.
+
+**Entropy pooling** strictly generalizes BL — views as constraints on the entire
+distribution, posterior by minimum KL divergence — and handles fat tails and
+views on volatility and correlation rather than means alone. It is deferred
+rather than dropped because it cuts against the very rationale for running BL: it
+is markedly less legible to an allocator, and legibility is the reason BL is here.
+
+### This is cheap, because the architecture already accommodates it
+
+- The crate is already `vv-portfolio-core` with BL as a module ([ADR-0002](./0002-numeric-core-runtime.md))
+- 1/N and market-cap are trivial
+- Minimum variance and maximum diversification reuse the Clarabel QP already
+  scheduled for Phase 5
+- **ERC needs Clarabel's exponential cones, which a pure QP solver would not have
+  provided** — an unplanned dividend of that choice
+- HRP needs no solver at all
+- The leave-one-out attribution machinery in [ADR-0001 §D5](./0001-black-litterman-model-conventions.md#d5--definitions-for-the-undefined-result-fields)
+  generalizes from view-versus-view to model-versus-model with no new mathematics
+
+## Consequence: claims need three axes, not one
+
+The honesty gate in the implementation plan catches overclaiming _completion_. It
+does not catch overclaiming _novelty_ — and a claim can be entirely true and
+still damage credibility. Nor does it distinguish "we implemented this correctly"
+from "this works well", which are separated by a large evidentiary gap.
+
+`docs/CLAIMS.md` therefore carries **three independent states per claim**:
+
+| Axis            | Question                                   | Gated by                                                                                                                            |
+| --------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Correctness** | Does the code compute what the paper says? | [Tier A](../specs/model-verification.md#tier-a--numerical-correctness) — invariants, golden vectors, cross-model identities         |
+| **Novelty**     | Is this actually differentiated?           | a written defensibility argument, reviewed. Default is **`commodity`**                                                              |
+| **Performance** | Does it work better than the alternatives? | [Tier B](../specs/model-verification.md#tier-b--model-validity) — pre-registered walk-forward protocol. **Never a single backtest** |
+
+Applied to what exists today:
+
+```yaml
+- claim: black-litterman-allocation
+  correctness: unbuilt
+  novelty: commodity # 1992, textbook, three OSS implementations
+  performance: unevaluated
+- claim: ml-enhanced-covariance
+  correctness: unbuilt
+  novelty: plausible # needs a defensibility argument before any claim
+  performance: unevaluated
+- claim: audited-reproducible-allocation
+  correctness: unbuilt
+  novelty: defensible # deterministic, signed, versioned — this is the real one
+  performance: not-applicable
+```
+
+**The `novelty: commodity` marking on Black-Litterman is the point of this
+table.** It does not stop the product from running BL or from saying so. It stops
+the decks from calling it IP.
+
+## Consequences
+
+**Positive.** BL becomes falsifiable. The comparison surface is more defensible
+than any single model. The abstraction work ([ADR-0004](./0004-allocation-model-abstraction.md))
+is required anyway for Phase 9 to slot in. HRP directly addresses the
+ill-conditioned-Σ problem that is BL's weakest point in this asset class.
+
+**Negative.** Scope grows: six additional models, plus a verification protocol
+that is more demanding than a test suite. Phase 5 splits into 5a and 5b.
+Comparison invites the question "so which one do I use?", which is a product
+question this ADR does not answer.
+
+**Risk this ADR creates.** A comparison harness with a weak verification protocol
+is _worse_ than no comparison — it manufactures authoritative-looking rankings out
+of estimation noise. [model-verification.md](../specs/model-verification.md)
+Tier B exists specifically to prevent that, and it is the harder half of the
+work.
+
+## Sign-off required
+
+- [ ] The deliverable is a comparison harness, not a BL engine
+- [ ] Model roster and phasing, including HRP as a first-class model
+- [ ] **`novelty: commodity` on Black-Litterman, and the deck edits that follow**
+- [ ] Entropy pooling deferred rather than dropped

--- a/docs/adr/0004-allocation-model-abstraction.md
+++ b/docs/adr/0004-allocation-model-abstraction.md
@@ -1,0 +1,243 @@
+# ADR-0004 — Allocation model abstraction
+
+|            |                                                                                            |
+| ---------- | ------------------------------------------------------------------------------------------ |
+| **Status** | **Proposed**                                                                               |
+| Date       | 2026-08-12                                                                                 |
+| Related    | [ADR-0002](./0002-numeric-core-runtime.md), [ADR-0003](./0003-portfolio-model-strategy.md) |
+| Spec       | [allocation-models.md](../specs/allocation-models.md)                                      |
+
+## Context
+
+[ADR-0003](./0003-portfolio-model-strategy.md) makes alternative allocation
+models peers rather than roadmap items. That only works if the abstraction is
+right. Get it wrong and every model becomes a special case with its own entry
+point, the comparison harness becomes a switch statement, and Phase 9 cannot slot
+in without surgery.
+
+## The obvious abstraction is wrong
+
+```rust
+trait AllocationModel {
+    fn allocate(&self, input: BlackLittermanInputDto) -> Weights;   // ✗
+}
+```
+
+This fails immediately. The models need radically different inputs: BL needs Σ,
+`w_mkt`, λ, τ and views; HRP needs only Σ; 1/N needs only the asset count. A
+single input type means every model receives fields it ignores, and **a caller
+who configures BL views and then runs HRP gets silence rather than an error** —
+the views simply have no effect and the result looks plausible.
+
+## The decomposition that works
+
+**The key observation: Black-Litterman is not an allocation model. It is a return
+estimator.**
+
+This is not a design opinion, it is what the specification already says.
+`black-litterman-model.md` separates _§Posterior Distribution_ from _§Optimal
+Portfolio Weights_, and E4 (`w* = (λΣ)⁻¹μ_BL`) is nothing but mean-variance
+optimization applied to `μ_BL`. BL produces expected returns; something else
+turns them into weights.
+
+Once that is seen, three orthogonal stages fall out:
+
+```
+  returns history  ──▶ ┌──────────────────────┐
+                       │ CovarianceEstimator  │ ──▶  Σ
+                       └──────────────────────┘
+                          sample · Ledoit-Wolf · ML (Phase 9)
+
+  market data ────────▶ ┌──────────────────────┐
+  + views               │   ReturnEstimator    │ ──▶  μ   (optional)
+                        └──────────────────────┘
+                          equilibrium · Black-Litterman · historical · entropy pooling
+
+  μ? + Σ? + constraints ▶ ┌──────────────────────┐
+                          │      Allocator       │ ──▶  w
+                          └──────────────────────┘
+                            MVO · MinVar · ERC · MaxDiv · HRP · 1/N · market-cap
+```
+
+Why this is the right cut:
+
+- **BL composes with any allocator.** Running BL posterior returns through an ERC
+  allocator is a real and interesting thing to do; under the naive abstraction it
+  is not expressible.
+- **HRP and 1/N simply declare they need no μ.** They are not special cases, they
+  are allocators with weaker requirements.
+- **Phase 9 slots into stage 1 without touching anything else.** The ML shrinkage
+  estimator is another `CovarianceEstimator`. This is the abstraction earning its
+  keep before it is built.
+- **Michaud is not a model at all** — it is a decorator over an allocator. That
+  falls out for free rather than needing a special case.
+
+## Design
+
+### Make the asset universe a type, not a convention
+
+The implementation plan §3.1 identifies the sharpest hazard in the contract: the
+covariance matrix is positional while the market weights and equilibrium returns
+are dictionaries, so correctness depends on an ordering agreement that nothing
+enforces. A dictionary reorder is invisible; a covariance reorder is
+catastrophic.
+
+**Do not defend this with a test. Make it unrepresentable.**
+
+```rust
+pub struct AssetUniverse { ids: Vec<AssetId>, index: HashMap<AssetId, usize> }
+
+// Constructible ONLY through the universe, which fixes the ordering.
+pub struct Weights          { universe: Arc<AssetUniverse>, v: DVector<f64> }
+pub struct ExpectedReturns  { universe: Arc<AssetUniverse>, v: DVector<f64> }
+pub struct Covariance       { universe: Arc<AssetUniverse>, m: DMatrix<f64> }
+
+impl AssetUniverse {
+    pub fn vector_from(&self, map: &HashMap<AssetId, f64>) -> Result<DVector<f64>>;
+    // errors on any missing asset or unknown key — never defaults to zero
+}
+
+impl Covariance {
+    /// The ONLY constructor. Symmetry, PSD and conditioning are established here,
+    /// once, so nothing downstream can receive an unvalidated matrix.
+    pub fn new(u: Arc<AssetUniverse>, m: DMatrix<f64>) -> Result<(Self, PsdReport)>;
+}
+```
+
+Parse, don't validate. The PSD repair and conditioning checks from
+[ADR-0001 §D6](./0001-black-litterman-model-conventions.md#d6--numerical-policy)
+happen at construction, and every function downstream takes a `Covariance` rather
+than a `DMatrix<f64>` — so "did anyone check this matrix?" stops being a question
+anyone can ask. Test T1.9 (permutation equivariance) becomes belt-and-braces
+rather than the primary defence.
+
+### Declare requirements, and validate the pipeline before running it
+
+```rust
+pub struct InputRequirements {
+    pub expected_returns: Requirement,     // Required | Optional | Unused
+    pub covariance:       Requirement,
+    pub market_weights:   Requirement,
+    pub views:            Requirement,
+    pub return_history:   Requirement,
+}
+
+pub trait Allocator {
+    fn id(&self) -> ModelId;
+    fn requires(&self) -> InputRequirements;
+    fn allocate(&self, ctx: &AllocationContext) -> Result<Allocation>;
+}
+```
+
+`requires()` is what turns the failure mode above into a real error. The harness
+checks a pipeline before executing it and reports:
+
+> `HRP` declares `expected_returns: Unused`. The configured `BlackLitterman`
+> return estimator will have no effect on the allocation. Either choose an
+> allocator that consumes expected returns, or remove the views.
+
+Silently ignoring configured inputs is how a product ships a screen full of views
+that change nothing.
+
+### The three traits
+
+```rust
+pub trait CovarianceEstimator {
+    fn id(&self) -> ModelId;
+    fn estimate(&self, returns: &ReturnPanel) -> Result<(Covariance, EstimatorDiagnostics)>;
+}
+
+pub trait ReturnEstimator {
+    fn id(&self) -> ModelId;
+    fn requires(&self) -> InputRequirements;
+    fn estimate(&self, ctx: &MarketContext) -> Result<(ExpectedReturns, ReturnDiagnostics)>;
+}
+
+pub trait Allocator { /* as above */ }
+```
+
+Every stage returns diagnostics alongside its result, because
+`BlackLitterman-Reference.md:22` requires an audit trail and a value with no
+provenance is not auditable. Diagnostics compose up the pipeline into the single
+`BlackLittermanDiagnosticsDto` the API returns.
+
+### Michaud is a decorator
+
+```rust
+pub struct ResampledAllocator<A: Allocator> {
+    inner: A,
+    draws: usize,
+    seed:  u64,     // explicit — never thread_rng; bit-determinism is a hard requirement
+}
+
+impl<A: Allocator> Allocator for ResampledAllocator<A> {
+    fn requires(&self) -> InputRequirements { self.inner.requires() }
+    fn allocate(&self, ctx: &AllocationContext) -> Result<Allocation> { /* average over draws */ }
+}
+```
+
+Resampled efficiency applies to _any_ allocator, not only mean-variance. Under
+the naive abstraction this would have been a second copy of every model.
+
+The explicit `seed` is not incidental: [ADR-0002](./0002-numeric-core-runtime.md#cross-platform-bit-determinism-is-a-hard-requirement)
+makes bit-identical output across platforms a correctness constraint, and a
+sampling model with an implicit RNG violates it on the first run.
+
+### Pipeline and comparison
+
+```rust
+pub struct Pipeline {
+    pub covariance: Box<dyn CovarianceEstimator>,
+    pub returns:    Option<Box<dyn ReturnEstimator>>,   // None for HRP, ERC, 1/N
+    pub allocator:  Box<dyn Allocator>,
+    pub constraints: ConstraintSet,
+}
+
+pub struct Comparison { pub pipelines: Vec<Pipeline> }
+```
+
+The comparison harness of [ADR-0003](./0003-portfolio-model-strategy.md) is a
+`Vec<Pipeline>` evaluated against one `MarketContext`. It needs no new
+mathematics — and the model-versus-model attribution reuses the leave-one-out
+machinery from ADR-0001 §D5 unchanged.
+
+## Evidence the abstraction is correct
+
+Good abstractions make true statements expressible. Under this decomposition, the
+implementation plan's behavioural requirements stop being assertions about one
+model and become **composition laws across independent code paths**:
+
+| Plan requirement                           | Becomes                                                       |
+| ------------------------------------------ | ------------------------------------------------------------- |
+| B3: Π through the optimizer ⇒ `w* = w_mkt` | `Equilibrium ∘ MVO ≡ MarketCapAllocator`                      |
+| B1: no views ⇒ `μ_BL = Π`                  | `BlackLitterman(views: ∅) ≡ Equilibrium`                      |
+| —                                          | `ERC(diagonal Σ) ≡ InverseVolatility`                         |
+| —                                          | `HRP(diagonal Σ) ≡ InverseVariance`                           |
+| —                                          | `MinVar(Σ = σ²I) ≡ EqualWeight`                               |
+| —                                          | `EntropyPooling(Gaussian prior, mean views) ≡ BlackLitterman` |
+
+Each is an exact identity between two independently implemented paths, checkable
+to machine precision, requiring no published table. That lattice of identities is
+the backbone of [Tier A verification](../specs/model-verification.md#tier-a--numerical-correctness) —
+and it only exists because the models were decomposed rather than boxed.
+
+## Rejected alternatives
+
+| Option                                                         | Why not                                                                                                                                               |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| One `AllocationModel` trait with a fat input                   | Every model ignores most fields; misconfiguration is silent; Michaud duplicates every model; Phase 9 needs surgery                                    |
+| Model-specific entry points (`vv_bl_solve`, `vv_hrp_solve`, …) | Comparison becomes a switch statement; no shared validation; the FFI surface grows without bound                                                      |
+| Generic type parameters instead of trait objects               | A heterogeneous `Vec<Pipeline>` is the core use case; monomorphization buys nothing at n ≤ 50 and costs the ability to configure pipelines at runtime |
+| Raw `DMatrix<f64>` throughout                                  | Reintroduces the ordering hazard the plan identifies as sharpest, and makes "has this been PSD-checked?" a permanent open question                    |
+
+## Consequences
+
+**Positive.** Phase 9 slots into stage 1 untouched. Michaud is free. The ordering
+hazard becomes structurally impossible rather than test-defended. Six exact
+composition identities appear that no single-model design would have exposed.
+
+**Negative.** More types than a direct implementation, and `Arc<AssetUniverse>`
+threading through every value is visible ceremony. The three-stage split must be
+established in Phase 1 — retrofitting it after BL is built means rewriting BL.
+
+**This ADR must be accepted before Phase 1 begins**, for that last reason.

--- a/docs/black-litterman-implementation-plan.md
+++ b/docs/black-litterman-implementation-plan.md
@@ -1,0 +1,923 @@
+# Black-Litterman Allocation Engine — Implementation Plan
+
+> **Status: PLAN ONLY. No solver exists. Nothing in this document may be cited as
+> evidence that the engine is built.** See [§9 Honesty gate](#9-honesty-gate--when-claims-may-change)
+> for the exact conditions under which product and investor claims may change.
+
+|                     |                                                                                                                   |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Revision            | 2 — 2026-08-12 (numeric core moved to Rust; ADR-0001 decisions folded in)                                         |
+| Scope               | Classical Black-Litterman solver, wired through CQRS → API → frontend                                             |
+| Explicitly deferred | ML shrinkage covariance estimator (Phase 9)                                                                       |
+| Model conventions   | [ADR-0001](./adr/0001-black-litterman-model-conventions.md) — **proposed, needs sign-off**                        |
+| Runtime             | [ADR-0002](./adr/0002-numeric-core-runtime.md) — Rust core, P/Invoke                                              |
+| Model strategy      | [ADR-0003](./adr/0003-portfolio-model-strategy.md) — **the deliverable is a comparison harness, not a BL engine** |
+| Abstraction         | [ADR-0004](./adr/0004-allocation-model-abstraction.md) — **must be accepted before Phase 1**                      |
+| Model specs         | [allocation-models.md](./specs/allocation-models.md) · [model-verification.md](./specs/model-verification.md)     |
+| Verified baseline   | `dotnet build vv.Platform.sln` → succeeded, 0 errors, 1 warning; cargo/rustc 1.97.1 present                       |
+
+---
+
+## 0. What exists today
+
+**Specification** — 45 documents, all `status: draft`, `version: 0.1.0`, across
+`Asset/portfolio-management/black-litterman/` (classical) and
+`AI/black-litterman-ai/` (ML-enhanced), plus a near-duplicate pair of
+`AI/FinancialModels/` and `AI/financial-models/` trees (see [§11](#11-housekeeping)).
+
+**Contracts** — `src/vv.Application/DTOs/Portfolio/BlackLittermanModels.cs`, 82 lines.
+
+**Computation** — none. `git grep -il blacklitterman -- src` returns three DTO
+files and the docs. No solver, no handler, no service, no interface, no test.
+
+**Frontend** — `JustAGhosT/vv-landing`, `components/corporate/model-results.tsx`,
+renders `data/models/results.json` behind the comment _"In a real application,
+this would be an API call."_ That repo is not checked out locally; Phase 8 is
+planned from description, not from reading its source.
+
+---
+
+## 1. The mathematical contract
+
+### 1.1 Notation
+
+| Symbol  | Shape         | Meaning                                       | DTO source                                     |
+| ------- | ------------- | --------------------------------------------- | ---------------------------------------------- |
+| n, k    | scalar        | asset count, view count                       | `Assets.Count`, `Views.Count`                  |
+| Σ       | n×n           | covariance of **excess** returns              | `CovarianceMatrix`                             |
+| w_mkt   | n×1           | market-cap weights                            | `MarketCapitalizationWeights`                  |
+| λ, τ    | scalar        | risk aversion, prior uncertainty              | `RiskAversionCoefficient`, `ConfidenceInPrior` |
+| Π       | n×1           | implied equilibrium excess returns            | derived, or `EquilibriumReturns`               |
+| P, Q, Ω | k×n, k×1, k×k | view matrix, values, uncertainty              | `Views[]`                                      |
+| μ_BL    | n×1           | posterior expected returns                    | `PosteriorExpectedReturns`                     |
+| M, Σ_p  | n×n           | posterior covariance of the mean / of returns | — / `PosteriorCovariance`                      |
+| w\*     | n×1           | optimal weights                               | `OptimalWeights`                               |
+
+### 1.2 The five equations
+
+**(E1) Reverse optimization** — `black-litterman-model.md:46`
+
+```
+Π = λ Σ w_mkt
+```
+
+**(E2) Posterior mean, precision form** — `black-litterman-model.md:125-126`
+
+```
+M    = [ (τΣ)⁻¹ + PᵀΩ⁻¹P ]⁻¹
+μ_BL = M [ (τΣ)⁻¹ Π + PᵀΩ⁻¹ Q ]
+```
+
+**(E3) Posterior mean, covariance form** — `black-litterman-model.md:130`
+
+```
+μ_BL = Π + τΣPᵀ [ τPΣPᵀ + Ω ]⁻¹ (Q − PΠ)
+```
+
+**E3 is the production path** — it inverts k×k (k ≤ ~5) rather than two n×n, and
+is well-posed at Ω = 0 where E2 is not. **E2 is implemented anyway and asserted
+to agree to 1e-10**: two independent derivations of the same quantity is the
+cheapest strong correctness signal available here.
+
+**(E4) Optimal weights** — `black-litterman-model.md:172`
+
+```
+w* = (λ R)⁻¹ μ_BL          R ∈ { Σ (default), Σ_p }   — ADR-0001 §D2
+```
+
+**(E5) Ω calibration** — four methods, ADR-0001 §D1. Default
+`Ω = diag(P(τΣ)Pᵀ)`.
+
+### 1.3 Behavioural contract
+
+`black-litterman-validation.md:31-52` and `black-litterman-model.md:191-195`:
+
+| #   | Requirement                             | Spec ref         |
+| --- | --------------------------------------- | ---------------- |
+| B1  | No views ⇒ μ_BL = Π exactly             | validation.md:31 |
+| B2  | 100% confidence ⇒ Pμ_BL = Q exactly     | validation.md:36 |
+| B3  | Π through the optimizer ⇒ w\* = w_mkt   | validation.md:41 |
+| B4  | Zero confidence ⇒ μ_BL → Π              | model.md:195     |
+| B5  | Scaling w_mkt by k leaves w\* unchanged | validation.md:52 |
+
+B3 is the highest-value test in the suite: E1 and E4 are exact inverses under the
+default risk matrix, so `w* = (λΣ)⁻¹(λΣw_mkt) = w_mkt` must hold to machine
+precision. It exercises the whole path — construction, factorization, ordering,
+FFI, decimal boundary — against a closed-form answer with no literature
+dependency.
+
+### 1.4 Four additional exact invariants
+
+Derived while resolving ADR-0001 §D1 and §D2. Each is exact, cheap, and
+independent of any published table:
+
+```
+1.  μ_BL is invariant to τ          under ProportionalToPrior and ConfidenceScaled
+2.  M ∝ τ                            (linearly)
+3.  Σ_p = (1 + τ)Σ                   when k = 0
+4.  w* = w_mkt / (1 + τ)             when k = 0 and R = Σ_p
+```
+
+(1) holds because Ω ∝ τ under both default calibrations, so τ cancels in E3.
+It does **not** hold under `Explicit` Ω. These become tests T1.12–T1.15.
+
+---
+
+## 2. Model conventions — resolved
+
+All six blocking questions from revision 1 are decided in
+**[ADR-0001](./adr/0001-black-litterman-model-conventions.md)**, which carries
+the full reasoning. Summary:
+
+| #   | Question                                                                                                                                                    | Decision                                                                                                                                                                    |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | Three conflicting Ω formulas                                                                                                                                | four named methods; default `ProportionalToPrior`; `model.md:161` **withdrawn** (contradicts B2); c=0 drops the view row, c=1 gives Ω=0                                     |
+| D2  | `PosteriorCovariance` undefined; Σ vs Σ_p in E4                                                                                                             | return `Σ_p = Σ + M`; optimizer risk matrix explicit, **default Σ** (B3 exact)                                                                                              |
+| D3  | Units undeclared                                                                                                                                            | required `ReturnBasis` enum; **no automatic conversion**; excess-return space throughout; `RiskFreeRate` is reporting-only                                                  |
+| D4  | Π both input and derived                                                                                                                                    | supplied wins; derived otherwise; divergence > 10% warns; source always in diagnostics                                                                                      |
+| D5  | **six** undefined result fields — `TiltMagnitude`, `ImpactScore`, `ImpliedConfidenceLevel`, `ImpliedRiskAversion`, `ReturnContribution`, `RiskContribution` | leave-one-out definitions, same optimizer and constraints as the main solve; **scores are non-additive**; `ImpliedRiskAversion` doubles as a self-consistency check (T1.17) |
+| D6  | Numerical policy unstated                                                                                                                                   | E3 production / E2 cross-check; Cholesky-solve never inverse; **relative** eigenvalue floor (spec's absolute 1e-6 rejected as scale-dependent); κ warn 1e10 / reject 1e14   |
+
+Errata pointers are in place in `black-litterman-model.md` (two),
+`black-litterman-views.md`, and `black-litterman-implementation.md`, so nobody
+implements the withdrawn formula from the spec tree.
+
+**D2's default is the one to argue about in review.** It is structured as a
+flipped default plus a golden re-baseline, not a rewrite.
+
+---
+
+## 3. DTO assessment and exact diff
+
+**Verdict: sufficient as a wire contract, insufficient as a computation
+contract.** All changes are additive except one enum tightening.
+
+### 3.1 `CovarianceMatrix` as `List<List<decimal>>`
+
+**Keep it on the wire. Never compute on it.** As JSON it is correct and
+idiomatic. As a compute type it carries no shape, symmetry, or PSD invariant —
+and, most sharply, **no binding to asset identity**. Correctness depends on
+positional agreement with `Assets`, while `MarketCapitalizationWeights` and
+`EquilibriumReturns` are _dictionaries_. Mixing positional and keyed
+representations of the same asset set in one DTO is the sharpest edge in this
+contract: a dictionary reorder is invisible, a covariance reorder is
+catastrophic. Hence T1.9.
+
+The fix is a validated mapping seam, not a new wire type. `Assets` is canonical
+ordering; every dictionary is projected onto it; any key not in `Assets`, or any
+asset missing from a dictionary, is a validation failure — never a default-to-zero.
+
+### 3.2 `decimal` / `double` boundary
+
+**`double` (Rust `f64`) inside, `decimal` at the wire, one tested seam in C#.**
+
+The case for `decimal` is exact base-10 arithmetic on money, and it does not
+apply: every input here is a statistical estimate carrying perhaps two
+significant figures. `double` gives 15–16 — six orders of magnitude more
+precision than the data contains. Under ADR-0002 the point is moot for the core
+(Rust computes in `f64`), but the C# boundary rules still bind:
+
+1. **Inbound** `decimal → double`: direct cast. ~1e-17 relative error, ~14 orders
+   below input noise.
+2. **Outbound** `double → decimal`: `Math.Round(x, 10, MidpointRounding.ToEven)`.
+   Fixed scale, deterministic, machine-independent.
+3. **Renormalize weights after rounding.** Rounding n weights independently does
+   not preserve `Σw = 1`; the result would render as `0.9999999999`. Renormalize,
+   then assert `sum == 1.0m` exactly.
+4. **Guard before converting**: `double.IsFinite(x)` and `|x| < 7.9e28`. A
+   non-finite value throws a typed domain exception naming the quantity — it
+   never becomes a decimal.
+5. **Never round-trip mid-computation.** One conversion in, one out.
+
+### 3.3 Field-level gaps
+
+| #   | Issue                                                                                  | Fix                                                                                                                                            |
+| --- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | No `ReturnBasis`                                                                       | add (D3)                                                                                                                                       |
+| 2   | No Ω calibration selector                                                              | add (D1)                                                                                                                                       |
+| 3   | `Confidence` semantics undefined; c=0 and c=1 break naive formulas                     | define + endpoint handling (D1)                                                                                                                |
+| 4   | τ unguarded — τ=0 makes (τΣ)⁻¹ undefined                                               | validator: τ ∈ (0, 1]                                                                                                                          |
+| 5   | λ unguarded — λ=0 makes (λΣ)⁻¹ undefined                                               | validator: λ > 0                                                                                                                               |
+| 6   | `ViewType` derivable from `AssetWeights`, can contradict it                            | `AssetWeights` authoritative; validate Absolute ⇒ one nonzero, Relative ⇒ weights sum to 0                                                     |
+| 7   | Π both input and derived                                                               | precedence + diagnostic (D4)                                                                                                                   |
+| 8   | No per-view Ω override                                                                 | add `ViewVariance`                                                                                                                             |
+| 9   | No result diagnostics                                                                  | add `BlackLittermanDiagnosticsDto` — `BlackLitterman-Reference.md:22` requires auditable I/O, and a result with no provenance is not auditable |
+| 10  | `PortfolioMetricsDto` non-nullable metrics that BL cannot compute                      | make nullable — see below                                                                                                                      |
+| 11  | No `AsOf` / `CurrencyCode`                                                             | add                                                                                                                                            |
+| 12  | `ConstraintDto.Type` is a bare `string`                                                | enum                                                                                                                                           |
+| 13  | **No returns-history input ⇒ the covariance estimator is unreachable through the API** | add `ReturnHistory` + `CovarianceEstimationMethod` — see below                                                                                 |
+
+**On gap 13 — a hole in revision 2 of this plan, not just in the DTO.** The input
+accepts a finished `CovarianceMatrix` and nothing else. But
+[§5](#5-minimum-viable-solver) puts a `CovarianceEstimator` trait with sample and
+Ledoit–Wolf implementations in Phase 4, and an estimator needs _returns history_
+to estimate from. **As written, Phase 4 ships code that no API caller can
+reach** — and, more seriously, the same gap means the Phase 9 ML estimator could
+never be exercised through the product either, while
+`veritasvault-investor-overview.html:346` sells "ML-enhanced covariance
+estimation" as a product capability.
+
+Fix: accept either a covariance matrix or a returns history, mutually exclusive,
+validated. The alternative — declaring covariance estimation permanently
+upstream and deleting the trait from Phase 4 — is a legitimate scope cut, but it
+must then be stated plainly, because it makes the deck's covariance claim
+unbuildable on this endpoint.
+
+**On gap 10** — `MaxDrawdown` and `ValueAtRisk` need a return history and are not
+derivable from BL inputs. As non-nullable `decimal` they reach the UI as `0`, and
+a displayed max drawdown of 0.00% is indistinguishable from a real answer. The
+engine computes only what the inputs support: `ExpectedReturn = w*ᵀμ_BL`,
+`Volatility = √(w*ᵀΣw*)`, `SharpeRatio = ExpectedReturn / Volatility` (μ is
+excess — no rf term), `AssetAllocation = w*`.
+
+### 3.4 Exact DTO diff
+
+**Safe to make now, and only now.** Verified: `PortfolioMetricsDto`,
+`BlackLittermanConstraintDto`, `InvestorViewDto` and `ViewImpactDto` have **no
+references anywhere outside their own declaration file**. The window closes the
+moment the API ships — which is why the DTO changes land in Phase 1, not Phase 7.
+
+```csharp
+// ── New enums ────────────────────────────────────────────────────────────────
+// Unspecified = 0 is deliberate: a missing JSON field deserializes to it and is
+// rejected loudly, rather than silently defaulting to a real value. This is the
+// D3 failure mode, eliminated structurally.
+public enum ReturnBasis { Unspecified = 0, Daily, Weekly, Monthly, Quarterly, Annual }
+
+// These two DO have intended defaults, so default(T) is the intended value.
+public enum OmegaCalibrationMethod { ProportionalToPrior = 0, ConfidenceScaled, IdzorekTilt, Explicit }
+public enum RiskMatrixChoice { PriorCovariance = 0, PosteriorCovariance }
+public enum ConstraintType { Unspecified = 0, Budget, Box, Group, Turnover }
+public enum CovarianceEstimationMethod { NotApplicable = 0, Sample, LedoitWolfShrinkage, MlShrinkage /* Phase 9 */ }
+
+// ── BlackLittermanInputDto: additive ─────────────────────────────────────────
+public required ReturnBasis ReturnBasis { get; set; }                  // D3
+public OmegaCalibrationMethod OmegaCalibration { get; set; }           // D1, default = ProportionalToPrior
+public RiskMatrixChoice OptimizerRiskMatrix { get; set; }              // D2, default = PriorCovariance
+public DateTime? AsOf { get; set; }
+public string? CurrencyCode { get; set; }
+public decimal MinimumTradeSize { get; set; }                          // D5, default 0 = report all
+
+// Gap 13 — supply EITHER CovarianceMatrix OR ReturnHistory + a method, never both.
+// Outer list is one row per period, inner is ordered by Assets. Validator enforces
+// the exclusion, rectangularity, and that periods >= assets + 1 for a sample estimate.
+public List<List<decimal>>? ReturnHistory { get; set; }
+public CovarianceEstimationMethod CovarianceEstimation { get; set; }   // default NotApplicable
+
+// ── InvestorViewDto: additive ────────────────────────────────────────────────
+public decimal? ViewVariance { get; set; }   // explicit Ω_ii; overrides Confidence
+
+// ── BlackLittermanConstraintDto: tightening ──────────────────────────────────
+- public required string Type { get; set; }
++ public required ConstraintType Type { get; set; }
+
+// ── PortfolioMetricsDto: nullability ─────────────────────────────────────────
+- public decimal MaxDrawdown { get; set; }
+- public decimal ValueAtRisk { get; set; }
++ public decimal? MaxDrawdown { get; set; }    // not derivable from BL inputs
++ public decimal? ValueAtRisk { get; set; }    // not derivable from BL inputs
+
+// ── BlackLittermanResultDto: additive ────────────────────────────────────────
+public required BlackLittermanDiagnosticsDto Diagnostics { get; set; }
+public ReturnBasis ReturnBasis { get; set; }   // echoed from input
+
+// ── New ──────────────────────────────────────────────────────────────────────
+public class BlackLittermanDiagnosticsDto
+{
+    public required string SolverStatus { get; set; }              // Optimal | Infeasible | ...
+    public required string EquilibriumSource { get; set; }          // Supplied | Derived   (D4)
+    public required string OmegaCalibrationUsed { get; set; }
+    public required string OptimizerRiskMatrixUsed { get; set; }    // D2 — which R was used
+    public required string CovarianceSource { get; set; }           // Supplied | Estimated:<method>  (gap 13)
+    public decimal CovarianceConditionNumber { get; set; }
+    public bool PsdRepairApplied { get; set; }
+    public int EigenvaluesClipped { get; set; }
+    public List<string> ViewsDroppedZeroConfidence { get; set; } = new();   // D1
+    public List<string> BindingConstraintIds { get; set; } = new();
+    public decimal? KktResidual { get; set; }
+    public List<DiagnosticWarningDto> Warnings { get; set; } = new();
+    public required string EngineVersion { get; set; }              // vv-portfolio-core semver + git sha
+    public int AbiVersion { get; set; }
+    public int SchemaVersion { get; set; }                          // payload schema, versioned independently of the ABI
+    public required string InputHash { get; set; }                  // SHA-256 of the canonical solver input — see §6.1
+    public long ComputeTimeMs { get; set; }
+}
+
+public class DiagnosticWarningDto
+{
+    public required string Code { get; set; }
+    public required string Message { get; set; }
+    public string? Field { get; set; }
+}
+```
+
+`BlackLittermanConstraintDto` is otherwise well-formed:
+`AssetWeights` + `LowerBound`/`UpperBound` is exactly the general linear
+constraint `L ≤ aᵀw ≤ U`, of which box, budget, sector and group constraints are
+all special cases. No further change needed.
+
+---
+
+## 4. Numerics — Rust core
+
+Full reasoning in **[ADR-0002](./adr/0002-numeric-core-runtime.md)**. The short
+version: .NET has no maintained QP solver (Accord archived at 3.8.0, OR-Tools is
+LP, alglib is GPL), so the C# route required hand-rolling Goldfarb–Idnani; the
+differential-test oracle was going to be another language regardless; and the
+Phase 9 specs are TensorFlow. Rust removes the first problem outright.
+
+Verified on crates.io 2026-08-12; local toolchain cargo/rustc 1.97.1:
+
+| Crate                  | Version | Licence        | Role                                               |
+| ---------------------- | ------- | -------------- | -------------------------------------------------- |
+| `nalgebra`             | 0.35.0  | Apache-2.0     | Cholesky, symmetric eigendecomposition, SVD        |
+| `clarabel`             | 0.11.1  | Apache-2.0     | interior-point conic solver — the QP               |
+| `serde` / `serde_json` | —       | MIT/Apache-2.0 | FFI payload                                        |
+| `schemars`             | —       | MIT            | JSON Schema emission for C# type generation (§6.1) |
+| `osqp`                 | 1.0.1   | Apache-2.0     | **dev-only** QP cross-check (T7.8)                 |
+
+**All permissive-licensed.** On the .NET side the only mature QP option was GPL;
+that constraint disappears here.
+
+**`osqp` is a dev-dependency behind a cargo feature (`--features qp-crosscheck`),
+never shipped.** Running two independent QP solvers and asserting they agree is
+the same logic as the E2/E3 cross-check, applied to the part of the pipeline with
+no closed-form oracle. Two constraints on how it is wired: it must not enter the
+production dependency graph (it would otherwise widen the audited surface for no
+runtime benefit), and it runs on **one** CI platform rather than all three,
+because the crate wraps the OSQP C library and would drag a C toolchain into
+every runner. _Confirm the C-binding detail in the Clarabel API spike; the
+feature-gating is correct either way._
+
+**Never form an explicit inverse.** Every `⁻¹` above is a `Cholesky::solve`.
+Faster, more accurate, and Cholesky _failing_ is the positive-definiteness check.
+
+Constraint handling is staged so each stage has a closed-form oracle:
+
+- **Stage 1** — unconstrained, `w* = (λR)⁻¹μ` by Cholesky solve. **Required for
+  the literature golden vectors, which are unconstrained.**
+- **Stage 2** — budget only (`Σw = 1`), closed form via Lagrange multiplier.
+- **Stage 3** — general inequalities via Clarabel, checked against stages 1 and 2
+  wherever constraints are slack.
+
+QP mapping: `max wᵀμ − (λ/2)wᵀΣw` ⟺ `min ½wᵀ(λΣ)w − μᵀw`, so `P = λΣ`, `q = −μ`;
+budget → `ZeroCone`; `L ≤ Aw ≤ U` → two `NonnegativeCone` blocks.
+**A spike must confirm Clarabel 0.11's Rust API surface before Phase 5 commits** —
+version and licence are verified, API ergonomics are not.
+
+---
+
+## 5. Minimum viable solver
+
+**In scope:** E1 → E5 → E3 → E4, constraint stages 1–3, and the D5 attribution —
+built on the ADR-0004 three-stage abstraction from the start, with Black-Litterman
+occupying the `ReturnEstimator` stage rather than being the whole pipeline.
+
+**Also in scope from [ADR-0003](./adr/0003-portfolio-model-strategy.md)** (Phases
+5a, 5b, 6b — specified in [allocation-models.md](./specs/allocation-models.md)):
+1/N, market-cap, minimum variance, ERC, maximum diversification, HRP, and the
+Michaud decorator. These are not scope creep — without at least 1/N and HRP,
+**nothing in this plan can tell you whether Black-Litterman is helping.**
+
+**Deferred, each with an interface seam now:**
+
+| Deferred                                      | Seam                        |
+| --------------------------------------------- | --------------------------- |
+| ML shrinkage covariance estimator (Phase 9)   | `CovarianceEstimator` trait |
+| Factor-space BL (`implementation.md:384-411`) | —                           |
+| Backtesting engine (`validation.md:200`)      | —                           |
+| Sensitivity analyzer (`validation.md:73-172`) | —                           |
+| Entropy pooling, robust BL, dynamic BL        | —                           |
+
+The MVP ships two classical estimators behind the trait: sample covariance and
+Ledoit–Wolf shrinkage (`covariance-estimation-methods.md:45`). **Ledoit–Wolf must
+be hand-written in Rust** — no crate supplies it, where sklearn would have. This
+is acceptable: a closed-form estimator is a very different proposition from a QP
+solver, and it is validated against sklearn output captured as a fixture.
+
+---
+
+## 6. Wiring
+
+```
+crates/vv-portfolio-core/          pure Rust — BL math, optimizer, attribution. No FFI.
+crates/vv-portfolio-ffi/           cdylib — C ABI shim: serde + panic containment only.
+src/vv.Analytics/           C# LibraryImport bindings, SafeHandle, IBlackLittermanEngine
+src/vv.Application/         command, handler, validator, DTO mapper
+src/vv.Api/                 controller
+```
+
+### 6.1 FFI surface
+
+```c
+int32_t vv_bl_solve(const uint8_t* req, size_t req_len, uint8_t** out, size_t* out_len);
+void    vv_bl_free(uint8_t* ptr, size_t len);
+int32_t vv_bl_abi_version(void);
+```
+
+Three rules that decide whether this works (full rationale in ADR-0002 §FFI):
+
+1. **One crossing per request, JSON payload.** The _entire_ solve happens
+   Rust-side including the `2k+1` attribution solves — attribution must use the
+   same optimizer and constraints as the main solve, so a per-solve crossing
+   would be both slow and incoherent.
+2. **Rust allocates, Rust frees.** C# wraps the pointer in a `SafeHandle` so
+   release survives exceptions. **Never `Marshal.FreeHGlobal` on Rust memory** —
+   different allocator, immediate heap corruption.
+3. **`catch_unwind` at every entry point.** Unwinding across FFI is UB.
+   `panic = "abort"` is rejected — it would kill the API process on bad input.
+
+C# side uses `[LibraryImport]` (source-generated, .NET 7+), not `[DllImport]`.
+
+**Payload types are generated, not mirrored by hand.** Two hand-maintained
+definitions of the same wire format drift silently — and the drift surfaces as
+wrong numbers, not as a compile error, because JSON deserialization fills
+missing fields with defaults.
+
+The pipeline is `schemars` on the Rust types → JSON Schema → C# generation
+(NJsonSchema / NSwag), run in CI with a check that the committed C# matches
+what the current Rust would generate.
+
+_Correction to an earlier suggestion in this plan's review: `typeshare` is not
+the right tool here — it targets TypeScript, Swift, Kotlin and Go, and C# is not
+among its first-class outputs._ The JSON Schema route is the workable one, and it
+pays a second dividend: the same schema validates actual responses in the API
+contract tests (T8), so a shape regression fails loudly at the boundary.
+
+The payload carries **`schema_version` independently of `vv_bl_abi_version`**.
+They change for different reasons — the ABI changes when the C function
+signatures change, the schema when a field is added — and conflating them forces
+a needless ABI bump for every additive field.
+
+**Input hashing.** `InputHash` is the SHA-256 of **the request bytes the FFI
+received**, hashed before parsing. This is deliberately not a hash of the HTTP
+request body: it binds the signed result to precisely the input the solver
+consumed, with no dependence on C#-side re-serialization or on a JSON
+canonicalization scheme. Documented on the field as "hash of the canonical solver
+input, not of the HTTP request". Together with `EngineVersion` (semver + git sha)
+this makes a result independently reproducible, which is what
+`BlackLitterman-Reference.md:22` actually needs from an audit trail.
+
+### 6.2 CQRS layer
+
+The existing pattern is `record …Command : IRequest<TResult>` →
+`…CommandHandler` with constructor-injected service + `ILogger`, both
+null-guarded. `DependencyInjection.AddApplication()` already registers MediatR
+and FluentValidation by assembly scan and wires `ValidationBehavior` +
+`LoggingBehavior`. **A validator dropped in `Validators/` is enforced
+automatically — no wiring needed.**
+
+```
+Commands/RunBlackLittermanAllocationCommand.cs
+Handlers/RunBlackLittermanAllocationCommandHandler.cs
+Validators/BlackLittermanInputDtoValidator.cs      every §3.3 guard
+Mapping/BlackLittermanDtoMapper.cs                 the single decimal ⇄ double seam
+```
+
+One line in `DependencyInjection.cs`:
+`services.AddScoped<IBlackLittermanEngine, RustBlackLittermanEngine>();`
+
+### 6.3 API
+
+Matching `MarketDataController`'s shape:
+
+```
+POST /api/portfolioallocation/black-litterman   → 200 BlackLittermanResultDto
+                                                  400 validation failure
+                                                  422 numerically infeasible
+```
+
+422 is deliberate and distinct from 400: a singular covariance or an infeasible
+constraint set is a well-formed request the solver cannot answer. It is reported
+as such, never as a silently repaired answer.
+
+### 6.4 Build and distribution
+
+The real cost of ADR-0002, and the largest new infrastructure in this plan:
+
+1. Cross-compile `win-x64`, `linux-x64`, `osx-arm64` (plus `linux-musl-x64` if
+   anything deploys to Alpine — glibc/musl is not interchangeable and fails at
+   load time).
+2. Package as NuGet with `runtimes/{rid}/native/` layout so `dotnet publish`
+   selects correctly. **Do not start with loose files copied to output** —
+   retrofitting is worse.
+3. CI: build on three runners, pack, publish to an internal feed.
+4. Pin `rust-toolchain.toml`; commit `Cargo.lock`.
+5. `vv_bl_abi_version` checked at startup so a mismatched binary is refused
+   rather than misread.
+
+### 6.5 Frontend cutover (`vv-landing`, separate repo, separate PR)
+
+1. Typed API client + zod validation on the response. Shape drift must fail
+   loudly — a `decimal` serialized as a JSON string is a realistic failure mode.
+2. Replace the direct `results.json` import with a fetch, and delete the
+   _"In a real application…"_ comment in the same commit that removes the
+   behaviour it describes.
+3. Real loading and error states.
+4. **The fixture stays reachable only behind an explicit `NEXT_PUBLIC_USE_FIXTURE`
+   flag, never as a silent fallback on error.** A silent fallback reproduces
+   today's problem with better camouflage: plausible numbers with no indication
+   the engine failed.
+5. CI check that fails if the fixture is imported outside the flagged path.
+
+---
+
+## 7. Test strategy
+
+Financial computation. A test asserting the solver returned _something_ is worse
+than no test — it converts "unverified" into a green check mark.
+
+Most tiers now run as `cargo test` in `vv-portfolio-core`: fast, no .NET, no DI, no HTTP.
+`proptest` covers the invariants across generated inputs rather than hand-picked
+cases.
+
+### T1 — Invariants and properties (`cargo test` + `proptest`)
+
+| #     | Test                                                                                  | Tolerance |
+| ----- | ------------------------------------------------------------------------------------- | --------- |
+| T1.1  | B1: no views ⇒ μ_BL = Π                                                               | 1e-12     |
+| T1.2  | **B3: w\* from Π equals w_mkt** (exact inverse round-trip)                            | 1e-10     |
+| T1.3  | B2: c→1 ⇒ Pμ_BL = Q                                                                   | 1e-9      |
+| T1.4  | B4: c→0 ⇒ μ_BL → Π                                                                    | monotone  |
+| T1.5  | B5: w_mkt scaled by k ⇒ w\* unchanged after normalization                             | 1e-10     |
+| T1.6  | Q = PΠ ⇒ μ_BL = Π at **every** confidence                                             | 1e-10     |
+| T1.7  | **E2 and E3 agree**                                                                   | 1e-10     |
+| T1.8  | Σ_p symmetric and PSD (min eigenvalue ≥ −1e-12)                                       | —         |
+| T1.9  | **Permutation equivariance**: reorder `Assets` ⇒ results permute identically          | exact     |
+| T1.10 | Determinism: identical input ⇒ byte-identical result                                  | exact     |
+| T1.11 | Blending monotonicity: c₁<c₂ ⇒ μ_BL(c₂) strictly closer to Q                          | —         |
+| T1.12 | **μ_BL invariant to τ** under both default Ω methods                                  | 1e-12     |
+| T1.13 | **M ∝ τ** linearly                                                                    | 1e-12     |
+| T1.14 | **Σ_p = (1+τ)Σ** when k=0                                                             | 1e-12     |
+| T1.15 | **w\* = w_mkt/(1+τ)** when k=0 and R=Σ_p                                              | 1e-10     |
+| T1.16 | μ_BL **does** vary with τ under `Explicit` Ω (negative control for T1.12)             | —         |
+| T1.17 | **`ImpliedRiskAversion` returns the input λ exactly** when Π is derived (ADR-0001 D5) | 1e-12     |
+
+T1.9 is the direct test for §3.1's positional/keyed hazard — the defect class
+most likely to ship undetected. T1.16 exists so T1.12 cannot pass vacuously.
+
+### T2 — Golden vectors from the literature
+
+**The load-bearing tier.** Sources named in the spec's own reference list
+(`BlackLitterman-Reference.md:38-41`): Black & Litterman (1992), Idzorek (2005),
+Meucci (2010), Walters (2014).
+
+| #    | Source                                                  | Reproduces            |
+| ---- | ------------------------------------------------------- | --------------------- |
+| T2.1 | He & Litterman (1999), 7-country example, δ=2.5, τ=0.05 | Π from E1             |
+| T2.2 | same, single relative view                              | μ_BL, w\*             |
+| T2.3 | same, two-view case                                     | μ_BL, w\*             |
+| T2.4 | Idzorek (2005) 8-asset example                          | Π, μ_BL, w\*          |
+| T2.5 | Idzorek confidence/tilt method                          | implied confidence, Ω |
+
+Five mandatory rules:
+
+1. **Every fixture carries provenance in its header** — paper, year, table, page.
+   A golden vector without a citation is a number someone made up.
+2. **Tolerances stated in the printed unit.** These tables print to one or two
+   decimals in percent, so the correct assertion is ±0.05% absolute on returns and
+   ±0.1% absolute on weights — _not_ a relative 1e-9. A too-tight tolerance fails
+   for reasons that are not bugs, and the reflex fix is to loosen it until green,
+   which destroys the test's value. Set it right once, with a comment saying why.
+3. **No golden vector is frozen until two independent derivations agree** — the
+   printed table _and_ an independent implementation (numpy/PyPortfolioOpt script
+   in `tests/reference/`, its output committed so CI needs no Python).
+4. **Disagreement is a finding, not a nuisance.** Investigate and write it up
+   before freezing. The Rust is never adjusted to match a single printed table.
+5. **State the conventions each fixture assumes** — τ, δ vs λ, Ω method, and
+   whether weights use Σ or Σ_p (ADR-0001 §D2). Most reproduction failures in this
+   model are convention mismatches, not arithmetic errors.
+
+T2.5 is partly self-validating: under `IdzorekTilt`, `ImpliedConfidenceLevel`
+should return approximately the `Confidence` that was input (ADR-0001 §D5).
+
+### T3 — Differential testing
+
+Seeded pseudo-random problems: n ∈ [3,30], k ∈ [0,5], Σ = AAᵀ + εI (guaranteed
+PD), τ ∈ [0.01,0.1], λ ∈ [1,10]. ~1000 cases against numpy/PyPortfolioOpt offline;
+inputs and reference outputs committed as fixtures. Max absolute deviation < 1e-9
+on μ_BL and w\*.
+
+Catches the class of error the golden vectors cannot — a bug correct on the
+literature's specific shapes and wrong elsewhere.
+
+### T4 — Conditioning and failure modes
+
+| #     | Scenario                                        | Required behaviour                                                   |
+| ----- | ----------------------------------------------- | -------------------------------------------------------------------- |
+| T4.1  | Σ singular (two identical assets)               | typed error naming the problem — **never a silent pseudo-inverse**   |
+| T4.2  | κ(Σ) > 1e10                                     | succeed + warn, condition number reported                            |
+| T4.3  | Σ non-symmetric on input                        | rejected at validation                                               |
+| T4.4  | Σ symmetric but indefinite                      | relative eigenvalue clipping, `PsdRepairApplied` set                 |
+| T4.5  | c = 0 and c = 1 exactly                         | defined behaviour per D1; no division by zero                        |
+| T4.6  | τ = 0, λ = 0, λ < 0                             | rejected at validation                                               |
+| T4.7  | Contradictory views ("A>B" and "B>A")           | solve **and warn** — the math is well-posed; the user should be told |
+| T4.8  | Duplicate view rows ⇒ P rank-deficient          | handled via E3 (k×k stays invertible when Ω ≻ 0)                     |
+| T4.9  | **No NaN or Inf ever crosses the FFI boundary** | asserted on every T1–T3 case                                         |
+| T4.10 | n=1, k=0 degenerate                             | defined behaviour                                                    |
+
+### T5 — FFI boundary (new under ADR-0002)
+
+| #    | Test                                                                                                                     |
+| ---- | ------------------------------------------------------------------------------------------------------------------------ |
+| T5.1 | Round-trip: C# request → Rust → C# result, no precision loss                                                             |
+| T5.2 | **Soak: 10⁵ solves, no leak** (RSS flat, handle count flat)                                                              |
+| T5.3 | A Rust panic surfaces as an error code, does not unwind into .NET                                                        |
+| T5.4 | Null / zero-length / malformed-JSON payload handled cleanly                                                              |
+| T5.5 | ABI version mismatch refused at startup, not misread                                                                     |
+| T5.6 | `cargo miri` clean on `vv-portfolio-core`                                                                                |
+| T5.7 | `SafeHandle` releases on the exception path                                                                              |
+| T5.8 | **Cross-RID determinism**: golden fixtures produce byte-identical canonicalized JSON on win-x64, linux-x64 and osx-arm64 |
+| T5.9 | Resolved `nalgebra` feature set contains no BLAS/LAPACK backend                                                          |
+
+T5.8 and T5.9 are not hygiene. `BlackLitterman-Reference.md:22` requires model
+inputs and outputs to be cryptographically signed; a one-ULP difference between a
+developer machine and a production container breaks signature verification and
+voids the audit trail. See [ADR-0002 §Cross-platform bit-determinism](./adr/0002-numeric-core-runtime.md#cross-platform-bit-determinism-is-a-hard-requirement).
+
+### T6 — Decimal boundary (C#)
+
+| #    | Test                                                                     |
+| ---- | ------------------------------------------------------------------------ |
+| T6.1 | `decimal → double → decimal` round-trip within the declared 1e-10 scale  |
+| T6.2 | Weights sum to **exactly** `1.0m` after rounding and renormalization     |
+| T6.3 | Non-finite double ⇒ typed exception, never a decimal                     |
+| T6.4 | `\|x\| > 7.9e28` ⇒ typed exception, never `OverflowException` from depth |
+| T6.5 | Rounding is `ToEven` and machine-independent                             |
+
+### T7 — Constraints and QP
+
+| #    | Test                                                                                                         |
+| ---- | ------------------------------------------------------------------------------------------------------------ |
+| T7.1 | Slack constraints ⇒ QP result equals stage-1 analytic solution (1e-9)                                        |
+| T7.2 | Budget-only ⇒ QP equals stage-2 closed form (1e-9)                                                           |
+| T7.3 | KKT residual < 1e-8 on every solved problem                                                                  |
+| T7.4 | Box constraints honoured to the exact bound                                                                  |
+| T7.5 | Group constraint `L ≤ aᵀw ≤ U` honoured                                                                      |
+| T7.6 | Infeasible set ⇒ explicit failure, **not** a projected approximation                                         |
+| T7.7 | Long-only + budget ⇒ all weights ≥ 0, sum to 1                                                               |
+| T7.8 | **Clarabel and OSQP agree to 1e-8** on every constrained solve (`--features qp-crosscheck`, one CI platform) |
+
+### T8 — Application and API contract
+
+| #    | Test                                                                    | Project                |
+| ---- | ----------------------------------------------------------------------- | ---------------------- |
+| T8.1 | Handler maps DTO → payload → DTO with no precision loss                 | `vv.Application.Tests` |
+| T8.2 | Validator rejects every §3.3 blocking case with a specific message      | `vv.Application.Tests` |
+| T8.3 | **He–Litterman fixture POSTed over HTTP reproduces the golden numbers** | `vv.Api.Tests`         |
+| T8.4 | Singular Σ ⇒ 422, not 500                                               | `vv.Api.Tests`         |
+| T8.5 | Malformed input ⇒ 400 with field-level detail                           | `vv.Api.Tests`         |
+| T8.6 | Missing `ReturnBasis` in JSON ⇒ 400 (not a silent `Daily` default)      | `vv.Api.Tests`         |
+
+T8.3 is not redundant with T2. It is the only test covering JSON serialization of
+`decimal`, dictionary ordering across the wire, and model binding — the layer
+where a numerically perfect engine still delivers wrong numbers to the UI.
+
+### T9 — Meta-verification: does the suite actually catch bugs?
+
+Everything above assumes these tests would fail if the code were wrong. That
+assumption is itself testable. See
+[model-verification.md M2](./specs/model-verification.md#m2--mutation-testing--does-the-suite-actually-catch-bugs).
+
+| #    | Test                                                                                                                                                                                                                                                                         | Cadence                   |
+| ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| T9.1 | **Mutation suite**: every seeded fault (transposed P, swapped Σ/Σ_p, withdrawn Ω formula, dropped τ, sign flip on `Q−PΠ`, `AssetUniverse` off-by-one, skipped PSD repair, inverse-vol in place of ERC, wrong HRP linkage, unrenormalized rounding) is caught by a named test | scheduled, not per-commit |
+| T9.2 | **Reproduction drill**: a signed result ≥ 6 months old, rebuilt at its recorded `EngineVersion` sha and replayed from its `InputHash`, produces byte-identical output                                                                                                        | quarterly                 |
+
+**A mutation that survives is a hole in the suite, and the fix is a new test.**
+Every genuine defect found in production becomes a permanent mutation.
+
+T9.2 measures the claim the product is actually sold on. T5.8 proves determinism
+across three platforms _today_; it proves nothing about the same platform after a
+compiler upgrade or a dependency bump — which is exactly the span an audit
+covers.
+
+### Coverage
+
+`vv-portfolio-core` holds a higher bar than the repo default — ≥95% line coverage
+(`cargo llvm-cov`) — with the explicit note that **coverage is a floor, not
+evidence of numerical correctness.** T2 and T3 are the evidence, and T9.1 is the
+evidence that T2 and T3 work.
+
+**Analytic-identity tolerances are derived, not chosen.** `tol = max(c·κ(Σ)·ε, floor)`
+with κ recorded in each fixture header, per
+[M4](./specs/model-verification.md#m4--tolerances-are-conventions-not-derivations).
+A fixed constant is unmeetable on an ill-conditioned fixture and vacuously loose
+on a trivial one. Golden vectors from published tables keep their absolute
+printed-unit tolerances.
+
+---
+
+## 8. Sequenced build order
+
+Each phase has a binary exit criterion. No numbered phase starts before the
+previous exits — **Phase 0b is the deliberate exception**: it is independent
+housekeeping and gating solver work on it would be make-work.
+
+| Phase  | Work                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Exit criterion                                                                                                                                                                                                                                                                                              |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **0**  | Ratify [ADR-0001](./adr/0001-black-litterman-model-conventions.md) (model conventions), [ADR-0003](./adr/0003-portfolio-model-strategy.md) (comparison harness + `novelty: commodity` on BL) and **[ADR-0004](./adr/0004-allocation-model-abstraction.md) — which must be accepted before Phase 1, because retrofitting the three-stage split after BL is built means rewriting BL**. **No code.**                                                                                                                                                                                                                                           | Sign-off on D1 (Ω default + withdrawal of `model.md:161`), D2 (Σ vs Σ_p — _the one to argue about_), D3, D5; on the model roster; and on the abstraction                                                                                                                                                    |
+| **0b** | **Housekeeping** ([§11](#11-housekeeping)) — H1 triage of the stale `vv.Application.Tests`, H2 dedupe of the case-variant doc trees. **Neither blocks solver work; run them in parallel.** H1 must land before Phase 7, H2 whenever convenient                                                                                                                                                                                                                                                                                                                                                                                               | H1: `vv.Application.Tests` compiles and runs in CI. H2: one `financial-models` tree, no broken inbound links                                                                                                                                                                                                |
+| **1**  | `crates/vv-portfolio-core` + `vv-portfolio-ffi` skeleton; **the ADR-0004 three-stage traits and the `AssetUniverse`/`Covariance` newtypes**; `src/vv.Analytics` bindings; DTO diff (§3.4); validator; decimal seam; **`schemars` → C# type generation**; CI build matrix + NuGet packaging; **`claims-gate` seeded with `docs/CLAIMS.md`**                                                                                                                                                                                                                                                                                                   | `dotnet build` green on all RIDs; **T5 and T6 pass** (incl. T5.8 cross-RID determinism); T4.3/T4.6 pass; generated C# matches committed C#; `claims-gate` green; **a pipeline with a mismatched `requires()` is rejected before execution, not silently ignored**                                           |
+| **2**  | E1 + E3 + E2, view-matrix builder, Ω `ProportionalToPrior` + `ConfidenceScaled`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | T1.1, T1.6, T1.7, T1.12–T1.14, T1.16, T2.1 pass                                                                                                                                                                                                                                                             |
+| **3**  | Stage-1 unconstrained weights; posterior covariance                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | **T1 complete, T2.1–T2.3 pass, T3 passes** ⇐ _[honesty gate](#9-honesty-gate--when-claims-may-change)_                                                                                                                                                                                                      |
+| **4**  | `IdzorekTilt` (Brent root-find) + `Explicit` Ω; `CovarianceEstimator` trait + sample + Ledoit–Wolf                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | T2.4, T2.5 pass; Ledoit–Wolf matches sklearn fixture                                                                                                                                                                                                                                                        |
+| **5**  | Clarabel API spike → stage-2 budget closed form → stage-3 QP                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | T7 complete                                                                                                                                                                                                                                                                                                 |
+| **5a** | **Benchmark allocators**: 1/N, market-cap ([ADR-0003](./adr/0003-portfolio-model-strategy.md))                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | EW._, MC._ and the `Equilibrium ∘ MVO ≡ MarketCap` identity pass                                                                                                                                                                                                                                            |
+| **5b** | **Risk-based allocators**: minimum variance, ERC (Clarabel exponential cones), maximum diversification, **HRP**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | MV._, ERC._, MD._, HRP._ pass; [identity lattice](./specs/allocation-models.md#composition-identity-lattice) green; HRP linkage tie-break documented and deterministic                                                                                                                                      |
+| **6**  | Attribution (D5), tilt magnitude, implied confidence, trade recommendations, computable metrics, diagnostics block                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Attribution non-additivity documented in the API contract; `MaxDrawdown`/`VaR` null, not 0                                                                                                                                                                                                                  |
+| **6b** | **Comparison harness** — `Vec<Pipeline>` over one context; model-vs-model attribution reusing the D5 machinery. Michaud decorator. **Tier B approaches needing no forward data: [B13](./specs/model-verification.md#b13--stability-capacity-and-implementability--no-forward-data-required) stability/capacity, [B11](./specs/model-verification.md#b11--synthetic-data-with-known-ground-truth) synthetic ground truth, [B17](./specs/model-verification.md#b17--ablation--which-component-is-actually-contributing) ablation. Start [B16](./specs/model-verification.md#b16--shadow-mode--the-only-truly-out-of-sample-test) shadow mode** | All pipelines emitted or none (B7); Michaud seeded and bit-deterministic (MR.2); non-convex constraints rejected under averaging (MR.5); **BL's stability elasticity measured against MVO — its actual claim**; DeMiguel 1/N regularity reproduced on synthetic data; shadow-mode recording live and signed |
+| **7**  | MediatR command + handler + DI + controller + OpenAPI                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | T8 complete                                                                                                                                                                                                                                                                                                 |
+| **8**  | `vv-landing` cutover (separate repo, separate PR)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Fixture reachable only behind the flag; CI check enforces it                                                                                                                                                                                                                                                |
+| **9**  | _Deferred_ — ML shrinkage covariance. Needs its own spike: `ort` (ONNX) is **release-candidate only** on crates.io as of 2026-08-12                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Out of scope for this plan                                                                                                                                                                                                                                                                                  |
+
+**Phase 0 is not overhead.** Five of its six decisions change the numbers.
+Building first and deciding later means the golden vectors get chosen to match
+whatever was built — which is how a model passes its own tests and fails against
+the literature.
+
+**Reviewer note for Phases 2–5:** these PRs need a reviewer who can check the
+mathematics, not only the code. A conventional review will pass a correct-looking
+implementation of the wrong equation.
+
+---
+
+## 9. Honesty gate — when claims may change
+
+The decks currently state this correctly.
+`veritasvault-corporate-deck.html:240` marks Black-Litterman allocation
+`Roadmap`; line 278 says roadmap items _including the Black-Litterman engine
+itself_ are unbuilt. **That stays accurate until the conditions below are met.**
+
+| Milestone                                         | Claim it licenses                                                                                                                    | Claim it does **not** license                                |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| Phase 3 exit: T1 + T2.1–T2.3 + T3 green on `main` | "Classical Black-Litterman posterior returns and unconstrained optimal weights, numerically validated against He & Litterman (1999)" | anything about constraints, ML covariance, or production use |
+| Phase 5 exit                                      | adds constrained allocation                                                                                                          | —                                                            |
+| Phase 7 exit                                      | adds "exposed via API"                                                                                                               | —                                                            |
+| Phase 8 exit                                      | adds "live in the product"                                                                                                           | —                                                            |
+| Phase 9                                           | **only then** may "ML-enhanced covariance estimation" (`veritasvault-investor-overview.html:346`, `:1035`) move off Roadmap          | —                                                            |
+
+1. **Passing tests written by the same session that wrote the solver is not
+   validation.** The gate is specifically T2 (external literature) and T3
+   (independent implementation) — evidence from outside the codebase.
+2. **A green CI run on a branch is not the gate.** It is green on `main`.
+3. **"ML-enhanced covariance estimation" is Phase 9.** Shipping classical BL does
+   not license that claim; the two are separate sentences in the investor
+   overview for good reason.
+
+### The gate is mechanical, not a promise
+
+A prose commitment not to overstate decays the moment someone edits a deck in a
+hurry before a meeting. Encode it instead.
+
+`docs/CLAIMS.md` holds a machine-readable claim ledger — one row per external
+capability claim, each carrying the deck file and line it appears in, its current
+state (`roadmap` | `live`), and the test IDs that gate promotion:
+
+Each claim carries **three independent axes**, because the gate above catches
+overclaiming _completion_ but not overclaiming _novelty_ — and a claim can be
+entirely true and still cost credibility. See
+[ADR-0003](./adr/0003-portfolio-model-strategy.md#consequence-claims-need-three-axes-not-one).
+
+```yaml
+- claim: black-litterman-allocation
+  appears_in: [docs/investor/veritasvault-corporate-deck.html:240]
+  correctness: unbuilt # gated by T1.*, T2.1-T2.3, T3
+  novelty: commodity # 1992, textbook, three OSS implementations
+  performance: unevaluated # gated by the Tier B protocol
+- claim: ml-enhanced-covariance
+  appears_in: [docs/investor/veritasvault-investor-overview.html:346]
+  correctness: unbuilt # gated by phase-9; no test exists yet
+  novelty: plausible # needs a written defensibility argument
+  performance: unevaluated
+- claim: audited-reproducible-allocation
+  correctness: unbuilt # gated by T5.8, T5.9, InputHash
+  novelty: defensible # deterministic, signed, versioned — the real one
+  performance: not-applicable
+```
+
+| Axis          | Gated by                                                                                                       | Default       |
+| ------------- | -------------------------------------------------------------------------------------------------------------- | ------------- |
+| `correctness` | [Tier A](./specs/model-verification.md#tier-a--numerical-correctness) green on `main`                          | `unbuilt`     |
+| `novelty`     | a written, reviewed defensibility argument                                                                     | `commodity`   |
+| `performance` | the full [Tier B](./specs/model-verification.md#tier-b--model-validity) protocol — **never a single backtest** | `unevaluated` |
+
+CI job `claims-gate` fails when either half of the contract is broken:
+
+- a claim's state exceeds its evidence — `correctness: verified` without green
+  gating tests, or `performance: consistent` without the pre-registration commit,
+  full-roster results, deflated Sharpe and bootstrap intervals — **or**
+- a deck line no longer carries the qualifier the ledger still requires.
+
+The second direction is the one that matters. It catches the actual failure mode
+— a deck edited before a meeting without the ledger being touched — rather than
+the theoretical one.
+
+**The axes are independent and normally disagree.** The expected steady state for
+Black-Litterman is `correctness: verified, novelty: commodity, performance:
+unevaluated`, and that is a perfectly good place to be: implemented correctly,
+not proprietary, not yet entitled to a performance claim. All three are
+defensible. Quietly promoting one on the evidence of another is not.
+
+---
+
+## 10. Decisions summary
+
+| Decision              | Choice                                                                   | Rationale                                                                                                           |
+| --------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| Numeric runtime       | **Rust core, P/Invoke** ([ADR-0002](./adr/0002-numeric-core-runtime.md)) | .NET has no maintained QP solver; avoids owning Goldfarb–Idnani; all deps permissive-licensed                       |
+| Linear algebra        | `nalgebra` 0.35.0                                                        | mature, documented; speed irrelevant at n ≤ 50                                                                      |
+| QP                    | `clarabel` 0.11.1                                                        | Rust-native reference implementation; Python/Julia are wrappers over it                                             |
+| Numeric type          | `f64` in core, `decimal` at wire                                         | inputs are estimates with ~2 significant figures; `double` gives 15–16                                              |
+| Posterior formula     | E3 in production, E2 as cross-check                                      | inverts k×k not n×n; well-posed at Ω=0; disagreement is a bug signal                                                |
+| Inversion             | `Cholesky::solve`, never explicit inverse                                | faster, more accurate, and failure _is_ the PSD check                                                               |
+| FFI shape             | one JSON call per solve                                                  | payload ~20 KB; avoids manual struct marshalling, the bug class that corrupts silently                              |
+| Ω default             | `ProportionalToPrior`, 3 alternatives behind a selector                  | spec is self-contradictory (D1); this form reproduces the literature                                                |
+| Optimizer risk matrix | Σ by default, Σ_p available                                              | B3 exact under Σ; **most likely decision to be overturned**                                                         |
+| Covariance wire type  | keep `List<List<decimal>>` + validator + mapper                          | fine as JSON, unusable for compute; `Assets` is canonical ordering                                                  |
+| ML shrinkage          | Phase 9, behind `CovarianceEstimator`                                    | classical Ledoit–Wolf is enough to ship                                                                             |
+| QP cross-check        | `osqp` dev-only, feature-gated, one CI platform                          | two independent solvers agreeing, where no closed-form oracle exists                                                |
+| FFI type maintenance  | `schemars` → JSON Schema → C# codegen                                    | hand-mirrored types drift silently and surface as wrong numbers, not compile errors; `typeshare` does not target C# |
+| Versioning            | `schema_version` separate from `abi_version`                             | they change for different reasons; conflating forces needless ABI bumps                                             |
+| Audit binding         | `InputHash` (SHA-256 of FFI request bytes) + `EngineVersion`             | makes a signed result independently reproducible, per `BlackLitterman-Reference.md:22`                              |
+| Determinism           | pure-Rust path pinned, proven cross-RID in CI                            | signing requirement makes bit-identical output a correctness constraint                                             |
+| Honesty gate          | mechanical `claims-gate` CI job over `docs/CLAIMS.md`                    | a prose commitment decays; a build failure does not                                                                 |
+
+---
+
+## 11. Housekeeping
+
+Two findings from the codebase survey. Both land in Phase 0b, before solver work.
+
+### H1 — `tests/vv.Application.Tests` is stale, not merely unwired
+
+It has two source files, **no `.csproj`, and no solution entry** — so it does not
+run today. Adding a csproj would **not** fix it, because both files reference a
+source shape that no longer exists:
+
+- `Services/Decorators/ValidationMarketDataServiceDecoratorTests.cs` imports
+  `vv.Application.Services.Decorators` and uses `IMarketDataService<T>`.
+  Verified: the decorator lives in `vv.Api.Services.Decorators`
+  ([ValidationMarketDataServiceDecorator.cs:10](src/vv.Api/Services/Decorators/ValidationMarketDataServiceDecorator.cs:10)),
+  the generic interface is declared in `src/vv.Api/Services/MarketDataService.cs`,
+  and `vv.Application`'s `IMarketDataService` is **non-generic**
+  ([IMarketDataService.cs:10](src/vv.Application/Services/IMarketDataService.cs:10)).
+- `Services/MarketDataServiceTests.cs` constructs `MarketDataService(repository, validator)`;
+  the actual constructor is `MarketDataService(IMarketDataRepository, ILogger<MarketDataService>)`
+  ([MarketDataService.cs:19](src/vv.Application/Services/MarketDataService.cs:19)).
+
+Work: move the decorator test to `vv.Api.Tests` and fix its usings; rewrite the
+service test against the current constructor; then add the csproj and the
+solution entry. **This must be done before Phase 7** or the new handler and
+validator tests will silently not execute either.
+
+### H2 — Case-variant duplicate doc trees
+
+`git ls-files` returns **19 tracked paths** across
+`AI/FinancialModels/` and `AI/financial-models/` — nine filenames duplicated,
+plus `financial-models/` holding both `portfolio-optimization.md` and
+`PortfolioOptimization.md`.
+
+**All nine cross-tree pairs are byte-identical** (verified by comparing git blob
+hashes, which is independent of what the working tree happens to contain). So
+deduplication is lossless — no merge required.
+
+On a case-insensitive filesystem only one of each pair can exist in the working
+tree, so edits to the "wrong" path are silently lost and the pair drifts apart.
+The trees are identical _today_; that is not stable.
+
+Procedure:
+
+1. Scan inbound links first — `git grep -l "FinancialModels"` — including the
+   appendix of this document and `Crosscutting/` references.
+2. Keep `financial-models/` (kebab-case matches the dominant convention in
+   `Domains/AI/`: `financial-ai/`, `black-litterman-ai/`, `time-series/`).
+3. Check whether `financial-models/portfolio-optimization.md` and
+   `financial-models/PortfolioOptimization.md` are also identical — **not yet
+   verified**; only the cross-tree pairs were compared.
+4. `git rm --cached` the exact `FinancialModels/` paths, fix links, commit.
+
+Verified with:
+
+```bash
+git ls-files "src/vv.Domain/Docs/Domains/AI/FinancialModels/" "src/vv.Domain/Docs/Domains/AI/financial-models/"
+```
+
+---
+
+## Appendix — spec documents consulted
+
+Classical tree (`Asset/portfolio-management/black-litterman/`): `index.md`,
+`black-litterman-overview.md`, `black-litterman-model.md`,
+`black-litterman-views.md`, `black-litterman-implementation.md`,
+`black-litterman-validation.md`.
+
+AI tree: `bl-ai-overview.md`, `bl-ai-components.md`, `bl-ai-implementation.md`,
+`bl-ai-reference.md`, the covariance/ML-shrinkage subtree (Phase 9 scope),
+`BlackLitterman-Overview.md`, `BlackLitterman-Implementation.md`,
+`BlackLitterman-Reference.md`, `covariance-estimation-methods.md`,
+`covariance-estimation-reference.md`.
+
+Contracts: `Crosscutting/Contracts/domain-interfaces.md` — declares
+`GetBlackLittermanParametersAsync` and `IPortfolioOptimizationService`, neither
+implemented.

--- a/docs/specs/allocation-models.md
+++ b/docs/specs/allocation-models.md
@@ -1,0 +1,365 @@
+# Allocation models — mathematical specification
+
+> **Status: SPECIFICATION ONLY. None of these models is implemented.**
+> Companion to [ADR-0003](../adr/0003-portfolio-model-strategy.md) (why a roster)
+> and [ADR-0004](../adr/0004-allocation-model-abstraction.md) (how they compose).
+> Verification in [model-verification.md](./model-verification.md).
+
+Black-Litterman itself is specified in
+[the implementation plan §1](../black-litterman-implementation-plan.md#1-the-mathematical-contract)
+and [ADR-0001](../adr/0001-black-litterman-model-conventions.md); it is not
+repeated here.
+
+**Notation.** `n` assets; `Σ` the n×n covariance of excess returns; `σ` the
+vector of volatilities with `σ_i = √Σ_ii`; `C` the correlation matrix,
+`Σ = diag(σ) C diag(σ)`; `μ` expected excess returns; `w` weights; `1` the ones
+vector. Every model returns weights summing to 1 unless stated otherwise.
+
+Each section gives the definition, the stage it occupies under ADR-0004, its
+input requirements, and **exact invariants** — identities checkable to machine
+precision with no reference to a published table. Those invariants are the
+primary correctness evidence; see
+[model-verification.md Tier A](./model-verification.md#tier-a--numerical-correctness).
+
+---
+
+## 1. Equal weight (1/N)
+
+**Stage:** Allocator · **Requires:** universe only · **Inverts Σ:** no
+
+```
+w_i = 1/n
+```
+
+**Invariants**
+
+| #    | Property                                                             |
+| ---- | -------------------------------------------------------------------- |
+| EW.1 | `Σw = 1`, all `w_i > 0`                                              |
+| EW.2 | Output is independent of Σ and μ — perturbing either changes nothing |
+| EW.3 | Permutation-invariant                                                |
+
+**Why it is in the roster.** DeMiguel, Garlappi & Uppal (2009) found 1/N
+frequently beats optimized portfolios out of sample, because estimation error
+swamps optimization gains. **This is the benchmark every other model must beat,
+and it is the cheapest to implement.** A comparison harness without it is not a
+comparison.
+
+_Reference:_ DeMiguel, Garlappi & Uppal (2009), _Optimal Versus Naive
+Diversification_, Review of Financial Studies 22(5). Spec: `equal-weighting.md`.
+
+---
+
+## 2. Market-capitalization weight
+
+**Stage:** Allocator · **Requires:** market caps · **Inverts Σ:** no
+
+```
+w = m / (1ᵀm)          m = vector of market capitalizations
+```
+
+**Invariants**
+
+| #    | Property                                             |
+| ---- | ---------------------------------------------------- |
+| MC.1 | `Σw = 1`                                             |
+| MC.2 | Scale-invariant: `w(cm) = w(m)` for `c > 0`          |
+| MC.3 | **`Equilibrium ∘ MVO ≡ MarketCap` exactly** — see §4 |
+
+MC.3 is the composition form of the implementation plan's requirement B3 and is
+the single most valuable identity in the suite.
+
+**Caveat for digital assets** ([ADR-0003](../adr/0003-portfolio-model-strategy.md)):
+market capitalization is contaminated by locked tokens, low float and wash
+trading. This model is the _measurement_ of the market portfolio, and its quality
+is bounded by the quality of that measurement — which also bounds Black-Litterman,
+since `w_mkt` is BL's prior.
+
+---
+
+## 3. Minimum variance
+
+**Stage:** Allocator · **Requires:** Σ · **Inverts Σ:** yes
+
+```
+min  wᵀΣw     s.t.  1ᵀw = 1   (+ constraint set)
+```
+
+Closed form with the budget constraint alone:
+
+```
+w = Σ⁻¹1 / (1ᵀΣ⁻¹1)
+```
+
+Implemented as a Cholesky solve, never an explicit inverse. With inequality
+constraints it becomes a Clarabel QP (`P = 2Σ`, `q = 0`).
+
+**Invariants**
+
+| #    | Property                                                                          |
+| ---- | --------------------------------------------------------------------------------- |
+| MV.1 | **`MinVar(Σ = σ²I) ≡ EqualWeight`** exactly                                       |
+| MV.2 | Scale-invariant in Σ: `w(cΣ) = w(Σ)` for `c > 0`                                  |
+| MV.3 | `wᵀΣw ≤ vᵀΣv` for every feasible `v` — the defining optimality property           |
+| MV.4 | Independent of μ entirely                                                         |
+| MV.5 | With no binding inequality constraints, the QP reproduces the closed form to 1e-9 |
+
+_Spec:_ `risk-based-overview.md:27`.
+
+---
+
+## 4. Equilibrium (reverse optimization)
+
+**Stage:** ReturnEstimator · **Requires:** Σ, `w_mkt`, λ · **Inverts Σ:** no
+
+```
+Π = λ Σ w_mkt
+```
+
+**Invariants**
+
+| #    | Property                                                                                                                                                                              |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| EQ.1 | **`Equilibrium ∘ MVO ≡ MarketCap`** — since `(λΣ)⁻¹(λΣw_mkt) = w_mkt`, exact to machine precision                                                                                     |
+| EQ.2 | `λ_implied = (w_mktᵀΠ)/(w_mktᵀΣw_mkt)` returns the input λ exactly ([ADR-0001 §D5](../adr/0001-black-litterman-model-conventions.md#d5--definitions-for-the-undefined-result-fields)) |
+| EQ.3 | Linear in `w_mkt` and in λ                                                                                                                                                            |
+
+EQ.1 exercises the entire numeric path — construction, factorization, ordering,
+FFI, decimal boundary — against a closed-form answer with no literature
+dependency. It is the first test to write and the last one that should ever fail.
+
+---
+
+## 5. Equal Risk Contribution (risk parity)
+
+**Stage:** Allocator · **Requires:** Σ · **Inverts Σ:** **no**
+
+Risk contribution of asset `i`:
+
+```
+RC_i = w_i (Σw)_i / √(wᵀΣw)          Σ_i RC_i = √(wᵀΣw)
+```
+
+ERC is the long-only portfolio with `RC_i = RC_j` for all `i, j`.
+
+**Do not solve the RC equations by root-finding.** Use the convex log-barrier
+formulation (Spinu 2013), which has a unique solution for `w > 0`:
+
+```
+min  ½ wᵀΣw − (1/n) Σ_i ln(w_i)      over w > 0,   then normalize w ← w / (1ᵀw)
+```
+
+**This requires exponential cones, not a QP.** Clarabel supports them; a pure QP
+solver would not have. That capability was an unplanned dividend of the
+[ADR-0002](../adr/0002-numeric-core-runtime.md) solver choice. Encode
+`t_i ≤ ln w_i` as `(w_i, 1, t_i) ∈ K_exp` and maximize `Σ t_i`.
+
+**Invariants**
+
+| #     | Property                                                                                     |
+| ----- | -------------------------------------------------------------------------------------------- |
+| ERC.1 | **`ERC(diagonal Σ) ≡ InverseVolatility`**, i.e. `w_i ∝ 1/σ_i` — exact                        |
+| ERC.2 | **`ERC(Σ = σ²I) ≡ EqualWeight`** — exact                                                     |
+| ERC.3 | Equal correlations _and_ equal volatilities ⇒ 1/N                                            |
+| ERC.4 | At the solution, `max_i RC_i − min_i RC_i < 1e-8` — the defining condition, checked directly |
+| ERC.5 | Scale-invariant in Σ                                                                         |
+| ERC.6 | All `w_i > 0` strictly — the log barrier guarantees an interior solution                     |
+
+ERC.1 is the sharpest test: inverse-volatility is often _mistaken_ for risk
+parity, and it is only equal to it when correlations are uniform. A bug that
+conflates them passes ERC.2 and fails ERC.1.
+
+_References:_ Maillard, Roncalli & Teïletche (2010), _The Properties of Equally
+Weighted Risk Contribution Portfolios_, JPM 36(4); Spinu (2013), _An Algorithm
+for Computing Risk Parity Weights_. Spec: `EqualRiskContribution.md`,
+`risk-parity-portfolio.md`.
+
+---
+
+## 6. Maximum diversification
+
+**Stage:** Allocator · **Requires:** Σ · **Inverts Σ:** yes
+
+Maximize the diversification ratio:
+
+```
+DR(w) = (wᵀσ) / √(wᵀΣw)
+```
+
+**Implement via the correlation-matrix reduction, not by optimizing DR
+directly.** Substituting `u_i = w_i σ_i` gives `wᵀσ = 1ᵀu` and
+`wᵀΣw = uᵀCu`, so maximizing DR is scale-invariant in `u` and reduces to:
+
+```
+solve   min uᵀCu  s.t. 1ᵀu = 1        (minimum variance on the CORRELATION matrix)
+then    w_i ∝ u_i / σ_i,  normalized
+```
+
+Reusing the §3 solver on `C` instead of `Σ`. Deriving it this way removes a
+separate non-linear optimization and makes the model a thin wrapper.
+
+**Invariants**
+
+| #    | Property                                                                                            |
+| ---- | --------------------------------------------------------------------------------------------------- |
+| MD.1 | **`MaxDiv(C = I) ≡ InverseVolatility`** — exact                                                     |
+| MD.2 | `MaxDiv(Σ = σ²I) ≡ EqualWeight`                                                                     |
+| MD.3 | `DR(w*) ≥ DR(v)` for every feasible `v`                                                             |
+| MD.4 | `DR ≥ 1` always, with equality iff the portfolio is a single asset or all correlations are 1        |
+| MD.5 | Reduction agrees with direct numerical maximization of DR to 1e-8 (validates the derivation itself) |
+
+_Reference:_ Choueifaty & Coignard (2008), _Toward Maximum Diversification_,
+JPM 35(1). Spec: `risk-based-overview.md:49`.
+
+---
+
+## 7. Hierarchical Risk Parity
+
+**Stage:** Allocator · **Requires:** Σ · **Inverts Σ:** **no — this is the point**
+
+The highest-value addition to the roster, and effectively absent from the current
+spec tree (one passing mention at `bl-ai-reference.md:134`, as a covariance
+technique rather than an allocator).
+
+**Stage 1 — tree clustering.** Correlation distance, then the distance between
+distance-vectors:
+
+```
+d_ij  = √( ½ (1 − ρ_ij) )
+D̄_ij = ‖ d_·i − d_·j ‖₂
+```
+
+Hierarchical agglomerative clustering on `D̄` (single linkage in the original).
+
+**Stage 2 — quasi-diagonalization.** Reorder Σ by the linkage tree so correlated
+assets are adjacent.
+
+**Stage 3 — recursive bisection.** For a cluster with sub-covariance `V`:
+
+```
+w̃      = diag(V)⁻¹ / Σ diag(V)⁻¹           inverse-variance within the cluster
+Var(V) = w̃ᵀ V w̃
+```
+
+Split the ordered list into halves `L` and `R`, set
+`α = 1 − Var(L)/(Var(L) + Var(R))`, scale `L` by `α` and `R` by `1−α`, recurse.
+
+**Invariants**
+
+| #     | Property                                                                                                                                                                       |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| HRP.1 | `Σw = 1`, all `w_i > 0` — long-only by construction, with no constraint imposed                                                                                                |
+| HRP.2 | **No matrix inversion anywhere in the algorithm** — assert structurally, e.g. by the absence of any solve/inverse call on the path                                             |
+| HRP.3 | **Invariant to the input ordering of assets** — the clustering re-orders internally, so a permuted input must give permuted-identical output                                   |
+| HRP.4 | Produces a finite, valid allocation when Σ is singular or `n > T`, where §3, §6 and Black-Litterman all fail                                                                   |
+| HRP.5 | `HRP(diagonal Σ)` reduces to inverse-variance weighting — **verify against the reference implementation rather than asserting; the reduction depends on linkage tie-breaking** |
+
+**Linkage tie-breaking must be explicitly defined and documented.** With a
+diagonal or near-uniform correlation matrix, distances tie and the clustering
+order becomes implementation-dependent. Left unspecified this silently violates
+the cross-platform bit-determinism requirement in
+[ADR-0002](../adr/0002-numeric-core-runtime.md#cross-platform-bit-determinism-is-a-hard-requirement),
+and it will also prevent golden vectors from reproducing. Match SciPy's documented
+linkage ordering, since the reference implementations use it.
+
+**Why it matters here.** HRP requires no expected returns and never inverts Σ.
+Both properties bite in digital assets: short histories, unstable correlations,
+frequent `n > T`, and return forecasts of dubious value. HRP.4 is the property no
+other model in this roster has.
+
+_Reference:_ López de Prado (2016), _Building Diversified Portfolios that
+Outperform Out of Sample_, JPM 42(4) — includes Python source, so golden vectors
+are directly obtainable.
+
+---
+
+## 8. Michaud resampled efficiency
+
+**Stage:** Allocator **decorator** — wraps any allocator ([ADR-0004](../adr/0004-allocation-model-abstraction.md))
+
+```
+for b in 1..B:
+    draw T observations ~ N(μ, Σ)
+    re-estimate μ̂_b, Σ̂_b from the draw
+    w_b = Allocator(μ̂_b, Σ̂_b)
+w̄ = (1/B) Σ_b w_b
+```
+
+**Invariants**
+
+| #    | Property                                                                                                                                                             |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MR.1 | `Σw̄ = 1` — an average of budget-feasible weights is budget-feasible                                                                                                  |
+| MR.2 | Bit-identical output for a fixed seed. **Explicit seed, never a thread RNG**                                                                                         |
+| MR.3 | Convergence: results at `B` and `2B` agree within Monte Carlo error                                                                                                  |
+| MR.4 | Strictly more diversified than the base allocator — `entropy(w̄) ≥ entropy(w_base)`                                                                                   |
+| MR.5 | Convex constraints survive averaging; **non-convex ones do not** — cardinality and minimum-position-size constraints must be re-applied after averaging, or rejected |
+
+MR.5 is a real trap: averaging weight vectors each satisfying "hold at most 10
+assets" can produce a portfolio holding all of them.
+
+**Intellectual property: resampled efficiency was patented.** Confirm the current
+status before implementing. Flagged, not assessed — this is a legal question, not
+a technical one.
+
+_Reference:_ Michaud (1998), _Efficient Asset Management_. Spec:
+`MichaudResampling.md`.
+
+---
+
+## 9. Entropy pooling — deferred
+
+**Stage:** ReturnEstimator (strictly, a distribution transformer)
+
+```
+p* = argmin_p  KL(p ‖ q)     s.t.  E_p[g(X)] = v,  Σp = 1,  p ≥ 0
+```
+
+Views are constraints on the entire distribution rather than on means alone, so
+volatility, correlation and tail views become expressible. Solved through the
+smooth convex dual in the Lagrange multipliers.
+
+**The invariant that makes it worth specifying now:**
+
+| #    | Property                                                                         |
+| ---- | -------------------------------------------------------------------------------- |
+| EP.1 | **`EntropyPooling(Gaussian prior, linear mean views) ≡ BlackLitterman`** exactly |
+
+Black-Litterman is the Gaussian-mean special case of entropy pooling. EP.1 is
+therefore a validation of _both_ implementations against each other, from
+completely independent code paths.
+
+**Deferred, not dropped.** It cuts against the rationale for running BL at all:
+entropy pooling is markedly less legible to an allocator, and legibility is
+BL's entire justification ([ADR-0003](../adr/0003-portfolio-model-strategy.md)).
+It earns its place when views on volatility or tails become a product
+requirement — which for digital assets is plausible.
+
+_Reference:_ Meucci (2008), _Fully Flexible Views: Theory and Practice_, Risk
+21(10). Mentioned at `black-litterman-views.md:185`.
+
+---
+
+## Composition identity lattice
+
+Every identity below connects two independently implemented paths and is checkable
+to machine precision without any published table. Together they are the backbone
+of Tier A verification.
+
+| Identity                                                | Tolerance    | Tests      |
+| ------------------------------------------------------- | ------------ | ---------- |
+| `Equilibrium ∘ MVO ≡ MarketCap`                         | 1e-10        | EQ.1, MC.3 |
+| `BlackLitterman(views: ∅) ≡ Equilibrium`                | 1e-12        | plan B1    |
+| `MinVar(σ²I) ≡ EqualWeight`                             | 1e-10        | MV.1       |
+| `ERC(diagonal Σ) ≡ InverseVolatility`                   | 1e-10        | ERC.1      |
+| `ERC(σ²I) ≡ EqualWeight`                                | 1e-10        | ERC.2      |
+| `MaxDiv(C = I) ≡ InverseVolatility`                     | 1e-10        | MD.1       |
+| `MaxDiv(σ²I) ≡ EqualWeight`                             | 1e-10        | MD.2       |
+| `HRP(diagonal Σ) ≡ InverseVariance`                     | verify first | HRP.5      |
+| `EntropyPooling(Gaussian, mean views) ≡ BlackLitterman` | 1e-9         | EP.1       |
+| `MaxDiv` reduction ≡ direct DR maximization             | 1e-8         | MD.5       |
+
+A bug in any one model surfaces as a broken identity against another. This is
+strictly stronger than testing each model in isolation, and it is available only
+because [ADR-0004](../adr/0004-allocation-model-abstraction.md) decomposed the
+models into composable stages rather than boxing each behind its own entry point.

--- a/docs/specs/model-verification.md
+++ b/docs/specs/model-verification.md
@@ -1,0 +1,641 @@
+# Model verification
+
+> Companion to [allocation-models.md](./allocation-models.md),
+> [ADR-0003](../adr/0003-portfolio-model-strategy.md) and
+> [ADR-0004](../adr/0004-allocation-model-abstraction.md).
+> **No model is implemented. Nothing here has been run.**
+
+## The question is two questions
+
+"How do we verify a model?" conflates two things that need completely different
+evidence, and conflating them is how financial software ships confident nonsense:
+
+|            | Question                                   | Answer type                                                                                                                                |
+| ---------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Tier A** | Does the code compute what the paper says? | Deductive. Exact identities, published tables, differential testing. A model either passes or has a bug.                                   |
+| **Tier B** | Is the model any good?                     | Inductive, and much weaker. Statistical evidence over a finite history, subject to noise, regime dependence and the analyst's own choices. |
+
+**Tier A can be settled. Tier B cannot.** A model can be numerically perfect and
+empirically useless, and a model that backtests beautifully can be a data-mining
+artifact. The two tiers gate different claims and must never be substituted for
+one another.
+
+This document is longer on Tier B than Tier A, because Tier A is mostly
+mechanical and Tier B is where the danger is.
+
+---
+
+## Tier A — numerical correctness
+
+Six layers, cheapest and strongest first. All run in CI on every commit.
+
+### A1 · Per-model exact invariants
+
+Each model's invariants are specified in
+[allocation-models.md](./allocation-models.md): EW.1–3, MC.1–3, MV.1–5, EQ.1–3,
+ERC.1–6, MD.1–5, HRP.1–5, MR.1–5, EP.1, plus B1–B5 and T1.12–T1.17 for
+Black-Litterman.
+
+These are analytic identities, not sampled comparisons. `MinVar(σ²I) ≡ 1/N` is
+either exactly true or the implementation is wrong.
+
+Implemented with `proptest` over generated inputs rather than fixed examples, so
+the invariant is asserted across the input space rather than at points someone
+chose.
+
+### A2 · The composition identity lattice
+
+The [identity lattice](./allocation-models.md#composition-identity-lattice)
+connects independently implemented models to each other:
+`Equilibrium ∘ MVO ≡ MarketCap`, `ERC(diagonal Σ) ≡ InverseVolatility`,
+`EntropyPooling(Gaussian, mean views) ≡ BlackLitterman`, and six more.
+
+**This is the strongest layer against independent bugs, and it is nearly free.**
+A bug in one model surfaces as a broken identity against another, so the models
+cross-check each other. It exists only because
+[ADR-0004](../adr/0004-allocation-model-abstraction.md) decomposed models into
+composable stages; a design where each model is a black box behind its own entry
+point cannot express any of it.
+
+**But it is blind to shared errors, and an earlier draft of this document
+overstated it by calling it simply "the strongest layer".** Every identity
+compares two paths that run through the _same_ `AssetUniverse` ordering, the same
+`Covariance` constructor and the same Cholesky wrapper. If the ordering
+projection is wrong, `Equilibrium ∘ MVO ≡ MarketCap` still passes — both sides
+are wrong identically. The lattice tests that the models agree, not that they are
+right.
+
+**A3 and A4 are therefore not optional and the lattice cannot substitute for
+them.** Published tables and independent implementations are the only layers that
+catch a defect in shared infrastructure, because they were computed by code that
+shares none of it.
+
+`ERC.1` deserves specific mention: inverse-volatility weighting is routinely
+_mistaken_ for risk parity, and equals it only under uniform correlations. An
+implementation that conflates the two passes the easy test (ERC.2) and fails
+ERC.1.
+
+### A3 · Golden vectors from published sources
+
+| Model               | Source                                                                  |
+| ------------------- | ----------------------------------------------------------------------- |
+| Black-Litterman     | He & Litterman (1999) 7-country example; Idzorek (2005) 8-asset example |
+| HRP                 | López de Prado (2016) — the paper includes Python source                |
+| ERC                 | Maillard, Roncalli & Teïletche (2010) worked examples                   |
+| Max diversification | Choueifaty & Coignard (2008)                                            |
+
+The five rules from the implementation plan §7 T2 apply to every golden vector
+here, not only to Black-Litterman's:
+
+1. Provenance in the fixture header — paper, year, table, page.
+2. **Tolerances in the printed unit.** Published tables give one or two decimals
+   in percent. The correct assertion is ±0.05% absolute on returns and ±0.1% on
+   weights, not a relative 1e-9. A too-tight tolerance fails for reasons that are
+   not bugs, and the reflex response is to loosen it until green — which destroys
+   the test.
+3. **Nothing is frozen until two independent derivations agree** — the printed
+   table _and_ an independent implementation.
+4. **Disagreement is a finding, not a nuisance.** Investigate and document before
+   freezing. Never adjust the implementation to match a single printed table.
+5. Conventions stated in the header. Most reproduction failures in this
+   literature are convention mismatches, not arithmetic errors.
+
+### A4 · Differential testing against reference implementations
+
+Seeded pseudo-random problems — `n ∈ [3,30]`, `Σ = AAᵀ + εI` — compared against
+Riskfolio-Lib, skfolio and PyPortfolioOpt offline, with inputs and reference
+outputs committed as fixtures so CI needs no Python. Max absolute deviation
+< 1e-9.
+
+Catches the failure class golden vectors cannot: a bug that is correct on the
+literature's specific shapes and wrong elsewhere.
+
+### A5 · Conditioning and failure modes
+
+Per the implementation plan §7 T4, extended across the roster. **The important
+addition is that models must fail differently and correctly:** given a singular Σ,
+minimum variance and Black-Litterman must fail loudly, while **HRP must succeed**
+(HRP.4). A test asserting that all models fail together would be asserting the
+wrong thing.
+
+### A6 · Determinism
+
+Cross-RID bit-identity per
+[ADR-0002](../adr/0002-numeric-core-runtime.md#cross-platform-bit-determinism-is-a-hard-requirement),
+with two model-specific hazards:
+
+- **HRP linkage tie-breaking** — ties are common with near-uniform correlations,
+  and unspecified tie-breaking is non-deterministic (HRP.5).
+- **Michaud seeding** — an implicit RNG breaks determinism on the first run
+  (MR.2).
+
+### Tier A exit
+
+A model is **correct** when A1–A6 pass on `main`. That is a binary, defensible
+state, and it is the only thing a `correctness:` claim in `docs/CLAIMS.md` may
+assert.
+
+---
+
+## Tier B — model validity
+
+### What can go wrong, and it usually does
+
+| Hazard                   | How it manifests here                                                                                                            |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Backtest overfitting** | Seven models on one history: the best in-sample Sharpe is biased upward by selection alone, even if all seven are worthless      |
+| **Data snooping**        | Every tuning decision — rebalance frequency, estimation window, τ, universe — is a free parameter searched against the same data |
+| **Look-ahead bias**      | Using a covariance estimated over a window that includes the rebalance date                                                      |
+| **Survivorship bias**    | Acute in digital assets. A universe of tokens that still exist in 2026 is a universe selected on survival                        |
+| **Ignoring costs**       | 1/N looks excellent until monthly rebalancing is costed; BL's tilts are real trades                                              |
+| **Regime dependence**    | A single aggregate Sharpe over a period containing one bull market says almost nothing                                           |
+
+**The comparison harness makes all of these worse, not better.** Producing a
+ranking is precisely the activity that manufactures authoritative-looking results
+out of estimation noise. A comparison harness with a weak Tier B protocol is more
+dangerous than no comparison at all —
+[ADR-0003](../adr/0003-portfolio-model-strategy.md) records this as the risk it
+creates.
+
+### Protocol
+
+**B1 · Pre-register before running — including the thresholds.** Model roster,
+universe construction rules, estimation window, rebalance frequency, transaction
+cost model, the metrics to be reported, **and the decision rule for each metric**
+— all fixed and committed to git _before_ the first backtest, with the commit
+hash recorded in the results.
+
+The threshold half is easy to omit and fatal to omit. **A measurement with no
+pre-committed decision rule is not a measurement; it is a number that gets
+rationalized after the fact**, which is precisely the behaviour the rest of this
+protocol exists to prevent. "Report the deflated Sharpe" without "and we require
+DSR > x" leaves the judgement exactly where the bias is.
+
+Every threshold is a judgement call and none of the values below is derivable
+from first principles — which is the reason to fix them in advance rather than
+after seeing the data:
+
+| Metric                     | Pre-committed rule (illustrative — set these deliberately)  |
+| -------------------------- | ----------------------------------------------------------- |
+| Deflated Sharpe (B5)       | DSR > 0 at 95%, with the trial count stated                 |
+| PBO (B10)                  | < 0.5, else the selection process is worse than a coin flip |
+| CPCV distribution (B9)     | 25th-percentile path still beats 1/N net of costs           |
+| Stability elasticity (B13) | BL's elasticity < MVO's, else BL's central claim fails      |
+| View calibration (B14)     | Brier score beats a constant-base-rate forecast             |
+| Capacity (B13)             | stated as an AUM figure, not a pass/fail                    |
+
+This is the single most effective measure against p-hacking and it costs nothing.
+Any deviation from the pre-registration is reported as a deviation, in the
+results, with its reason.
+
+**B2 · Walk-forward only.** The estimation window strictly precedes each
+rebalance date. No in-sample fitting, ever. Sketched already at
+`black-litterman-validation.md:200`.
+
+**B3 · Universe must include the dead.** Delisted, depegged and abandoned assets
+stay in the universe until the date they became untradeable. Omitting them is the
+difference between a real result and a flattering one, and in digital assets that
+difference is very large.
+
+**B4 · Costs and turnover are part of the metric, not a footnote.** Report
+gross and net side by side. A model whose advantage disappears after costs does
+not have an advantage.
+
+**B5 · Adjust for the number of trials.** Report the **deflated Sharpe ratio**
+(Bailey & López de Prado 2014) alongside the raw one, with the trial count stated
+— where trials means every model _and_ every parameter variant examined, not just
+the ones reported.
+
+**B6 · Report differences with uncertainty, never point estimates.** Bootstrap
+confidence intervals on Sharpe _differences_ between models. Two models 0.1
+Sharpe apart over three years are indistinguishable, and presenting them as
+ranked is a false statement dressed as a table.
+
+**B7 · Report the whole roster, always.** Never publish only the winner. This is
+enforced structurally: the harness emits all pipelines or none.
+
+**B8 · Split by regime.** Report by volatility regime and market direction
+alongside the aggregate. A model that wins on average by winning enormously in
+one quarter is a different proposition from one that wins consistently, and the
+aggregate hides which you have.
+
+---
+
+## Tier B, extended — approaches beyond the backtest
+
+B1–B8 above are the discipline for _when you backtest_. But a walk-forward
+backtest is one path through one history, and the industry default of reporting
+its Sharpe as though it were an estimate with no variance is the original sin of
+this field.
+
+Nine further approaches follow. The useful way to rank them is not by cost or
+rigour but by **how hard they are to game** — because the failure mode here is
+never an honest analyst reading a number wrong, it is a well-meaning analyst
+iterating until the number looks good.
+
+| #     | Approach                                | Gaming resistance               | Needs forward data?     | Cost                       |
+| ----- | --------------------------------------- | ------------------------------- | ----------------------- | -------------------------- |
+| B16   | Shadow mode / paper trading             | **maximum**                     | yes — quarters          | low compute, high patience |
+| B13   | Stability, capacity, implementability   | **very high**                   | **no**                  | very low                   |
+| B14   | Calibration testing                     | high, and accumulates           | partial                 | low                        |
+| B11   | Synthetic data with known ground truth  | high                            | **no**                  | medium                     |
+| B12   | Cross-universe validation               | high                            | no (uses other markets) | medium                     |
+| B15   | Reality Check / SPA                     | high — it _corrects_ for gaming | yes                     | low                        |
+| B9    | Combinatorially purged cross-validation | medium                          | yes                     | high compute               |
+| B10   | Probability of backtest overfitting     | medium                          | yes                     | low, given B9              |
+| B17   | Ablation                                | medium                          | either                  | low                        |
+| B1–B8 | Single walk-forward backtest            | **lowest**                      | yes                     | medium                     |
+
+**The recommendation that falls out: start at the top, not the bottom.** B11,
+B13 and B14 require no forward data at all, so they can run in CI from the day
+the models exist — long before any backtest is credible. They belong in Phases
+5b and 6b, not in a later research phase.
+
+### B9 · Combinatorially purged cross-validation
+
+Partition the history into `N` blocks, hold out `k` at a time, train on the rest.
+This yields `C(N,k)` backtest paths instead of one, and therefore a **distribution
+of Sharpe ratios** rather than a point.
+
+Two corrections are mandatory, not optional:
+
+- **Purge** — drop training observations whose estimation window overlaps the
+  test blocks. This bites here specifically because covariance is estimated over a
+  trailing window, so a naive split leaks future data into the estimator.
+- **Embargo** — leave a gap after each test block, because serial correlation
+  carries information across the boundary.
+
+Report the distribution. A model whose median path beats 1/N but whose 25th
+percentile does not has told you something a single path never would.
+
+_Reference:_ López de Prado, _Advances in Financial Machine Learning_ (2018), ch. 7 & 12.
+
+### B10 · Probability of backtest overfitting
+
+CSCV yields **PBO** — an explicit estimate of the probability that the
+configuration selected as best in sample lands below median out of sample.
+
+Crucially, **PBO is reported for the harness as a whole, not per model**, because
+the harness _is_ the selection process. Comparing seven models and reporting the
+winner is exactly the activity PBO measures the damage of.
+
+_Reference:_ Bailey, Borwein, López de Prado & Zhu (2016), _The Probability of
+Backtest Overfitting_, Journal of Computational Finance 20(4).
+
+### B11 · Synthetic data with known ground truth
+
+**The approach that bridges Tier A and Tier B, and the one most under-used.**
+
+Generate returns from a _known_ `(μ, Σ)`. The optimal portfolio is then known
+analytically, so the question stops being "did it make money" and becomes
+**"does the model recover the known optimum, and how quickly as T grows?"** That
+is a deductive question with an exact answer, and no amount of iterating can
+p-hack it, because fresh data is free and unlimited.
+
+What to generate:
+
+| Scenario              | Tests                                                          |
+| --------------------- | -------------------------------------------------------------- |
+| Gaussian, `T ≫ n`     | baseline recovery; every model should converge                 |
+| Gaussian, `T ≈ n`     | estimation-error sensitivity — **the entire reason BL exists** |
+| `T < n`               | only HRP should survive (HRP.4); the rest must fail loudly     |
+| Student-t returns     | robustness to the fat tails BL's Gaussian prior assumes away   |
+| Regime-switching      | do models detect or smear the break?                           |
+| Correlation → 1 shock | crisis behaviour, constructed rather than hoped for            |
+
+**Reproduce the DeMiguel result as a test.** At realistic `n` and `T`, naive 1/N
+should beat mean-variance optimization. If the harness does not show that, the
+harness is wrong — this is a known empirical regularity being used as a fixture.
+
+Resample real history with the **stationary block bootstrap** (Politis & Romano 1994) where preserving actual autocorrelation and tail structure matters more
+than knowing ground truth.
+
+### B12 · Cross-universe validation — more markets, not more time
+
+History is finite; markets are not. Run the identical roster on equities, FX,
+commodities and separate crypto sub-sectors.
+
+This is **genuinely independent data** rather than the same history resampled,
+which is what makes it stronger than B9. A model that works on one universe and
+nowhere else has told you it was fitted to that universe. Overfitting four
+unrelated markets simultaneously is very hard.
+
+It also directly tests the [ADR-0003](../adr/0003-portfolio-model-strategy.md)
+concern that BL's market-cap prior is weaker in digital assets than in equities:
+if BL's edge over 1/N is materially smaller in crypto than in equities, that
+concern is confirmed empirically rather than argued.
+
+### B13 · Stability, capacity and implementability — no forward data required
+
+**The highest value-per-unit-risk in this document**, because none of it requires
+forward data and therefore none of it can be data-snooped. Partly specified
+already at `black-litterman-validation.md:73-172` and `:352`.
+
+**Stability.** Perturb Σ by a small relative amount and measure the weight
+response:
+
+```
+elasticity = ‖Δw‖₁ / (‖ΔΣ‖_F / ‖Σ‖_F)
+```
+
+A model whose allocation swings on a 1% covariance perturbation is unusable
+regardless of its backtest Sharpe. **This tests Black-Litterman's actual claim.**
+BL's entire pitch — `black-litterman-overview.md:35` — is that it is more stable
+than mean-variance optimization and produces less extreme weights. A Sharpe
+ranking does not evaluate that claim at all; an elasticity comparison against MVO
+evaluates exactly it, in minutes, with no history required.
+
+**Capacity.** At what AUM does market impact consume the edge? In digital assets,
+with thin books outside the majors, this is frequently decisive and almost always
+omitted. A strategy with a 2.0 Sharpe and $5m capacity is a different product
+from the same Sharpe at $500m.
+
+**Implementability.** Turnover, Herfindahl concentration, maximum position,
+number of holdings, and the count of positions below minimum tradeable size —
+already listed at `black-litterman-validation.md:352` and never wired to anything.
+
+### B14 · Calibration rather than performance
+
+Black-Litterman is a _Bayesian_ model that emits a posterior distribution, and
+almost nobody ever checks whether that distribution is calibrated. Two tests, and
+the second is the most product-relevant thing in this document.
+
+**Posterior predictive coverage.** If the model states a 90% interval, do 90% of
+realizations fall inside it? Report a reliability diagram over rebalance dates.
+Systematic under-coverage means the posterior is overconfident, which propagates
+directly into position sizing.
+
+**View calibration — the one that matters most here.** Do views submitted at 80%
+confidence come true 80% of the time? Track per view, per author, per source;
+report reliability diagrams and Brier scores.
+
+This is the test that can invalidate everything upstream of it: **if analysts'
+stated confidence is miscalibrated, the Ω calibration in
+[ADR-0001 §D1](../adr/0001-black-litterman-model-conventions.md#d1--view-uncertainty-ω-calibration)
+is wrong no matter how numerically perfect the solver is.** A flawless Tier A and
+a badly calibrated view pipeline produce confident, precise, wrong allocations.
+
+It also closes a loop the specs already anticipate: measured historical accuracy
+feeds Ω through the `Explicit` calibration method — exactly the "historical
+method" at `black-litterman-model.md:165` and the accuracy assessment at
+`confidence-calibration.md:41`. Neither is currently connected to anything.
+
+And unlike a backtest, calibration evidence **accumulates continuously in
+production** without a research exercise.
+
+_References:_ Brier (1950); Gneiting, Balabdaoui & Raftery (2007),
+_Probabilistic Forecasts, Calibration and Sharpness_, JRSS-B 69(2).
+
+### B15 · Formal multiple-testing tests
+
+Deflated Sharpe (B5) adjusts a single reported statistic. **White's Reality Check**
+and **Hansen's SPA test** answer the sharper question directly: _does any model in
+this roster beat the benchmark, once the number of models tried is accounted for?_
+
+Given B7 already requires reporting the whole roster, the roster is exactly the
+input these tests need. The benchmark is 1/N.
+
+_References:_ White (2000), _A Reality Check for Data Snooping_, Econometrica
+68(5); Hansen (2005), _A Test for Superior Predictive Ability_, JBES 23(4).
+
+### B16 · Shadow mode — the only truly out-of-sample test
+
+Run the harness live against real market data with no capital deployed. Record
+every allocation, timestamped and signed.
+
+**This is where the audit infrastructure already in the plan pays off in an
+unexpected way.** `InputHash` + `EngineVersion` + signature
+([§3.4](../black-litterman-implementation-plan.md#34-exact-dto-diff)) make a
+shadow-mode record **tamper-evident**: the allocation, the exact input that
+produced it, and the exact engine version are bound together cryptographically
+before the outcome is known. A shadow record cannot be quietly revised, a model
+version cannot be swapped in retroactively, and a losing period cannot be dropped.
+
+It is slow — meaningful evidence takes quarters — and it is the only approach on
+this list that cannot be gamed at all. **Start it the day Phase 6b ships**, so
+that by the time anyone wants to make a performance claim, real out-of-sample
+evidence already exists rather than being a year away.
+
+### B17 · Ablation — which component is actually contributing?
+
+Remove one component at a time and measure the delta: views, shrinkage,
+constraints, the confidence weighting.
+
+The sharpest of these has an uncomfortable edge: **if removing views changes the
+allocation materially less than the noise floor, Black-Litterman is an expensive
+way to compute equilibrium returns.** That question deserves an answer before the
+product is built around views, and it is cheap to ask — it reuses the
+leave-one-out machinery from [ADR-0001 §D5](../adr/0001-black-litterman-model-conventions.md#d5--definitions-for-the-undefined-result-fields)
+with no new mathematics.
+
+---
+
+### What Tier B can and cannot establish
+
+**It cannot establish that a model will work.** It can only fail to reject a
+model over one finite history under one set of choices. Every result is
+conditional on the pre-registered protocol, and stating that conditionality is
+part of reporting the result.
+
+Useful framing — **what would falsify each model?**
+
+| Model             | Falsified by                                                                                                                            |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Black-Litterman   | Posterior allocations that do not beat their own equilibrium prior net of costs — BL failing to add value over the input it starts from |
+| ERC / risk parity | Realized risk contributions diverging materially from equal out of sample                                                               |
+| HRP               | Underperforming inverse-variance weighting, its own degenerate case                                                                     |
+| Michaud           | Not improving out-of-sample stability over the base allocator it wraps                                                                  |
+| 1/N               | Being beaten, net of costs, with statistical significance — **which is the bar for the entire product**                                 |
+
+Each falsification test is more informative than a Sharpe ranking, because each
+targets the specific claim the model makes rather than a generic performance
+number.
+
+### Tier B exit
+
+Graduated, because the approaches differ enormously in strength:
+
+| Claim state   | Requires                                                                                                                                                                                               |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `unevaluated` | default                                                                                                                                                                                                |
+| `stable`      | B13 only — stability, capacity and implementability, no forward data. **Available from Phase 5b**, and sufficient to say "allocations are stable under input perturbation", which is BL's actual claim |
+| `recovers`    | B11 — known-ground-truth recovery, including the DeMiguel 1/N regularity reproduced                                                                                                                    |
+| `calibrated`  | B14 — posterior coverage and view reliability over a stated sample                                                                                                                                     |
+| `evaluated`   | B1–B8 full backtest protocol + B9/B10 (CPCV distribution and PBO) + B12 cross-universe                                                                                                                 |
+| `consistent`  | all of the above **and** B15 (SPA against 1/N) **and** ≥ 4 quarters of B16 shadow mode in which **live behaviour matched the backtest's stated expectations**                                          |
+
+**A single backtest never gates any of these.** `stable`, `recovers` and
+`calibrated` need no forward data at all, so they are reachable long before any
+backtest is credible — which is the point of the ordering.
+
+**There is deliberately no `strong` state, and no state asserting that one model
+outperforms another.** An earlier draft had one, gated on four quarters of shadow
+mode; [M1](#m1--the-sample-sizes-available-cannot-support-the-performance-claims-anyone-wants)
+shows that twelve monthly observations cannot distinguish a Sharpe of 1.0 from
+one of 0.5, and that doing so with confidence takes over a decade of data this
+product will never have. The top state is therefore `consistent` — live behaviour
+did not contradict what the backtest predicted — which is answerable at realistic
+sample sizes. "This model beats that one" is not, and the ledger has no way to
+say it.
+
+---
+
+---
+
+## Measuring the measurement
+
+The document to this point asserts that a suite of tests establishes correctness.
+That assertion deserves the same scepticism it applies to everything else. Six
+weaknesses, in descending order of how much they matter.
+
+### M1 · The sample sizes available cannot support the performance claims anyone wants
+
+This is the most uncomfortable item here and no protocol fixes it.
+
+The standard error of a Sharpe estimate is approximately `√((1 + SR²/2)/T)`. For
+an annualized Sharpe near 1.0 measured on monthly data:
+
+| Observations    | SE of annualized Sharpe | 95% interval around a true SR of 1.0 |
+| --------------- | ----------------------- | ------------------------------------ |
+| 12 (1 year)     | ≈ 1.0                   | roughly [−1.0, 3.0]                  |
+| 36 (3 years)    | ≈ 0.6                   | roughly [−0.2, 2.2]                  |
+| ~200 (17 years) | ≈ 0.25                  | roughly [0.5, 1.5]                   |
+
+**Distinguishing a Sharpe of 1.0 from 0.5 with confidence takes on the order of a
+decade and a half of monthly data.** Digital assets do not have that history, and
+neither will this product.
+
+Paired comparison is meaningfully better — two allocation models over the same
+universe share most of their market exposure, so the _difference_ has far lower
+variance than either level, and relative claims need perhaps three to five times
+fewer observations than absolute ones. But that still means **years, not
+quarters.**
+
+Consequences, stated rather than buried:
+
+- **The `strong` claim state as originally defined was wrong.** Gating it on
+  "≥ 4 quarters of shadow mode" gated a strong claim on evidence that cannot
+  support one. Twelve monthly observations distinguish essentially nothing.
+- Performance _ranking_ between models should probably never be claimed at all on
+  this product's realistic data. The comparison harness is valuable for showing
+  an allocator _how the models differ and why_, not for declaring a winner.
+- The claim states that survive scrutiny are the ones measurable at realistic
+  sample sizes: **`stable`, `recovers`, `calibrated`.** Those are real, defensible
+  and reachable. The top state is renamed `consistent` — live behaviour did not
+  contradict the backtest's stated expectations, which is answerable — replacing
+  any state that asserted one model beats another, which is not.
+
+If this reads as deflating, it is the correct amount of deflating. The
+alternative is a ranking table built out of noise.
+
+### M2 · Mutation testing — does the suite actually catch bugs?
+
+The whole framework rests on the assumption that these tests would fail if the
+code were wrong. That is testable, and largely untested in practice.
+
+Seed known faults and require the suite to catch every one:
+
+| Mutation                                     | Must be caught by                     |
+| -------------------------------------------- | ------------------------------------- |
+| Transpose P in the view matrix               | T2 golden vectors; T1.9 permutation   |
+| Swap Σ and Σ_p in the optimizer              | T2; the 1/(1+τ) invariant T1.15       |
+| Use `model.md:161`'s withdrawn Ω formula     | T1.3 (B2, 100% confidence)            |
+| Sign flip on `Q − PΠ`                        | T1.6 (view agreeing with equilibrium) |
+| Drop the τ factor from Ω                     | T1.12 τ-invariance                    |
+| Off-by-one in the `AssetUniverse` projection | T1.9; A3 golden vectors               |
+| Skip PSD repair                              | T4.4                                  |
+| Inverse-variance in place of ERC             | ERC.1                                 |
+| Single- vs average-linkage in HRP            | HRP golden vectors                    |
+| Round weights without renormalizing          | T6.2                                  |
+
+**Any mutation that survives the suite is a hole in the suite, and the fix is a
+new test, not a shrug.** Run as a scheduled job rather than per-commit; the
+mutation set is committed alongside the tests and grows whenever a real bug is
+found in production — every genuine defect becomes a permanent mutation.
+
+This is the direct answer to "is the measurement strong": a suite that has never
+been shown to fail on a known-bad implementation is decoration.
+
+### M3 · The audit claim — the actual differentiator — is unmeasured
+
+[ADR-0003](../adr/0003-portfolio-model-strategy.md) concludes that the defensible
+value is auditability, not mathematics. Everything above measures the mathematics.
+
+**T5.8 proves determinism across three platforms _today_. It proves nothing about
+the same platform a year from now**, after a compiler upgrade, a dependency bump
+or a refactor — which is exactly the span an audit covers.
+
+Add a **reproduction drill**, run quarterly:
+
+1. Take a signed result at least six months old.
+2. Rebuild the engine at the `EngineVersion` git sha it records.
+3. Replay the input identified by its `InputHash`.
+4. Assert bit-identical output.
+
+A failure means the audit trail does not actually work, however green the rest of
+CI is. This is the only test that measures the claim the product is being sold
+on, and it is cheap.
+
+### M4 · Tolerances are conventions, not derivations
+
+Constants of 1e-8, 1e-9, 1e-10 and 1e-12 are scattered through these specs. They
+came from convention.
+
+A defensible tolerance derives from conditioning: the achievable accuracy of a
+Cholesky solve is roughly `κ(Σ) · ε_machine`. For a fixture with κ = 10⁶ that is
+about 1e-10 — which happens to match, but by luck rather than reasoning. On an
+ill-conditioned fixture a fixed 1e-10 is unmeetable; on a trivially conditioned
+one it is vacuously loose and would pass a genuinely broken implementation.
+
+**Derive each tolerance from the fixture's own condition number** —
+`tol = max(c · κ(Σ) · ε, floor)` with `c` stated — and record κ in the fixture
+header alongside the citation. Golden vectors from published tables keep their
+absolute printed-unit tolerances (A3 rule 2); this applies to the analytic
+identities, where machine precision is the only limit.
+
+### M5 · Claims have no expiry
+
+A claim verified once stays verified forever in the ledger. A `performance`
+assessment from two years ago, in a different volatility regime, is not current
+evidence of anything.
+
+Add `verified_at` per axis and a staleness rule that **automatically demotes**:
+`correctness` never expires while its tests stay green in CI; `calibrated`
+expires after two quarters without a refresh; `performance` expires after four.
+An expired axis reverts to its default and `claims-gate` fails if a deck still
+asserts it.
+
+### M6 · A framework that is too slow to run measures nothing
+
+CPCV is `C(N,k)` full backtests. If the complete Tier B suite takes a week, it
+will be run once, before a board meeting, and never again — at which point it is
+theatre.
+
+Budget it explicitly: Tier A under five minutes per commit; the no-forward-data
+Tier B set (B11, B13, B17) under an hour nightly; the full backtest tier
+quarterly. **If a layer cannot meet its budget, reduce its scope deliberately and
+`log()` what was dropped** rather than letting it quietly stop running.
+
+---
+
+## How this binds to claims
+
+`docs/CLAIMS.md` carries three independent axes per
+[ADR-0003](../adr/0003-portfolio-model-strategy.md#consequence-claims-need-three-axes-not-one):
+
+| Axis          | Gated by                                   | Default       |
+| ------------- | ------------------------------------------ | ------------- |
+| `correctness` | Tier A on `main`                           | `unbuilt`     |
+| `novelty`     | a written, reviewed defensibility argument | `commodity`   |
+| `performance` | the full Tier B protocol                   | `unevaluated` |
+
+The `claims-gate` CI job fails when a claim's state exceeds its evidence, and
+when a deck line drops a qualifier the ledger still requires.
+
+**The three axes are independent and it is normal for them to disagree.** The
+expected steady state for Black-Litterman is
+`correctness: verified, novelty: commodity, performance: unevaluated` — and that
+is a perfectly good position to be in. It says: this is implemented correctly,
+it is not proprietary, and we have not yet earned the right to claim it performs.
+All three are defensible statements. What is not defensible is quietly promoting
+any one of them on the evidence of another.

--- a/src/vv.Domain/Docs/Domains/Asset/portfolio-management/black-litterman/black-litterman-implementation.md
+++ b/src/vv.Domain/Docs/Domains/Asset/portfolio-management/black-litterman/black-litterman-implementation.md
@@ -3,13 +3,13 @@ document_type: guide
 classification: internal
 status: draft
 version: 0.1.0
-last_updated: '2025-05-31'
+last_updated: "2025-05-31"
 applies_to:
-- Core
+  - Core
 reviewers:
-- '@tech-lead'
+  - "@tech-lead"
 priority: p2
-next_review: '2026-05-31'
+next_review: "2026-05-31"
 ---
 
 ```src/vv.Domain/Docs/Domains/Asset/black-litterman-implementation.md
@@ -28,22 +28,24 @@ This document provides practical guidance for implementing the Black-Litterman m
 The Black-Litterman implementation is structured into these core components:
 
 ```
-┌─────────────────────┐      ┌─────────────────────┐      ┌─────────────────────┐
-│                     │      │                     │      │                     │
-│   Data Providers    │─────▶│   Black-Litterman   │─────▶│    Optimization     │
-│                     │      │       Engine        │      │      Engine         │
-│                     │      │                     │      │                     │
-└─────────────────────┘      └─────────────────────┘      └─────────────────────┘
-         ▲                            ▲                            │
-         │                            │                            │
-         │                            │                            ▼
-┌─────────────────────┐      ┌─────────────────────┐      ┌─────────────────────┐
-│                     │      │                     │      │                     │
-│    Market Data      │      │    View Manager     │      │    Portfolio        │
-│                     │      │                     │      │    Constructor      │
-│                     │      │                     │      │                     │
-└─────────────────────┘      └─────────────────────┘      └─────────────────────┘
-```
+
+┌─────────────────────┐ ┌─────────────────────┐ ┌─────────────────────┐
+│ │ │ │ │ │
+│ Data Providers │─────▶│ Black-Litterman │─────▶│ Optimization │
+│ │ │ Engine │ │ Engine │
+│ │ │ │ │ │
+└─────────────────────┘ └─────────────────────┘ └─────────────────────┘
+▲ ▲ │
+│ │ │
+│ │ ▼
+┌─────────────────────┐ ┌─────────────────────┐ ┌─────────────────────┐
+│ │ │ │ │ │
+│ Market Data │ │ View Manager │ │ Portfolio │
+│ │ │ │ │ Constructor │
+│ │ │ │ │ │
+└─────────────────────┘ └─────────────────────┘ └─────────────────────┘
+
+````
 
 ### Core Components
 
@@ -90,7 +92,7 @@ View specifications require:
 def prepare_data(returns_df, market_caps_df, risk_free_rate):
     """
     Prepare input data for Black-Litterman model.
-    
+
     Parameters:
     -----------
     returns_df : DataFrame
@@ -99,7 +101,7 @@ def prepare_data(returns_df, market_caps_df, risk_free_rate):
         Market capitalizations for each asset
     risk_free_rate : float
         Risk-free rate (annualized)
-        
+
     Returns:
     --------
     tuple
@@ -107,21 +109,21 @@ def prepare_data(returns_df, market_caps_df, risk_free_rate):
     """
     # Calculate excess returns
     excess_returns = returns_df.subtract(risk_free_rate / 12, axis=0)  # Monthly adjustment
-    
+
     # Calculate covariance matrix
     cov_matrix = excess_returns.cov() * 12  # Annualize
-    
+
     # Calculate market weights
     total_market_cap = market_caps_df.sum()
     market_weights = market_caps_df / total_market_cap
-    
+
     # Estimate risk aversion parameter
     market_return = (excess_returns * market_weights).sum(axis=1).mean() * 12  # Annualized
     market_variance = (market_weights.T @ cov_matrix @ market_weights)
     risk_aversion = market_return / market_variance
-    
+
     return cov_matrix, market_weights, risk_aversion
-```
+````
 
 ### 2. Equilibrium Returns Calculation
 
@@ -129,7 +131,7 @@ def prepare_data(returns_df, market_caps_df, risk_free_rate):
 def calculate_equilibrium_returns(cov_matrix, market_weights, risk_aversion):
     """
     Calculate implied equilibrium returns using reverse optimization.
-    
+
     Parameters:
     -----------
     cov_matrix : DataFrame
@@ -138,7 +140,7 @@ def calculate_equilibrium_returns(cov_matrix, market_weights, risk_aversion):
         Market capitalization weights
     risk_aversion : float
         Risk aversion parameter
-        
+
     Returns:
     --------
     Series
@@ -146,7 +148,7 @@ def calculate_equilibrium_returns(cov_matrix, market_weights, risk_aversion):
     """
     # Π = λΣw
     implied_returns = risk_aversion * cov_matrix @ market_weights
-    
+
     return implied_returns
 ```
 
@@ -156,7 +158,7 @@ def calculate_equilibrium_returns(cov_matrix, market_weights, risk_aversion):
 def create_view_matrix(views, asset_list):
     """
     Create view matrix P and view vector Q from view specifications.
-    
+
     Parameters:
     -----------
     views : list of dict
@@ -166,7 +168,7 @@ def create_view_matrix(views, asset_list):
         - 'value': expected return (absolute) or return difference (relative)
     asset_list : list
         Complete list of assets in the investment universe
-        
+
     Returns:
     --------
     tuple
@@ -174,14 +176,14 @@ def create_view_matrix(views, asset_list):
     """
     n_assets = len(asset_list)
     n_views = len(views)
-    
+
     # Create asset index mapping
     asset_indices = {asset: i for i, asset in enumerate(asset_list)}
-    
+
     # Initialize P matrix and Q vector
     P = np.zeros((n_views, n_assets))
     Q = np.zeros(n_views)
-    
+
     # Fill P and Q based on view specifications
     for i, view in enumerate(views):
         if view['type'] == 'absolute':
@@ -195,17 +197,27 @@ def create_view_matrix(views, asset_list):
             P[i, asset_indices[asset1]] = 1
             P[i, asset_indices[asset2]] = -1
             Q[i] = view['value']
-    
+
     return P, Q
 ```
 
 ### 4. View Uncertainty Calibration
 
+> **CANONICAL — see ADR-0001 §D1**
+> (`docs/adr/0001-black-litterman-model-conventions.md`, repository root).
+> This function is the adopted confidence-bearing calibration, superseding the
+> variant in [black-litterman-views.md](./black-litterman-views.md) (omits $\tau$)
+> and the withdrawn option 2 in [black-litterman-model.md](./black-litterman-model.md).
+> Two additions on implementation: `conf == 0` drops the view's row from `P`/`Q`
+> rather than dividing by zero, and `conf == 1` yields `omega_ii = 0`, which
+> requires the covariance form of the posterior — the precision form inverts
+> $\Omega$ and is undefined there.
+
 ```python
 def calibrate_omega(P, cov_matrix, tau, confidences):
     """
     Calibrate view uncertainty matrix Omega.
-    
+
     Parameters:
     -----------
     P : ndarray
@@ -216,7 +228,7 @@ def calibrate_omega(P, cov_matrix, tau, confidences):
         Uncertainty scaling parameter
     confidences : list
         Confidence levels for each view (0-1)
-        
+
     Returns:
     --------
     ndarray
@@ -224,16 +236,16 @@ def calibrate_omega(P, cov_matrix, tau, confidences):
     """
     # Calculate base uncertainty for each view
     base_uncertainty = np.diag(P @ (tau * cov_matrix) @ P.T)
-    
+
     # Scale by confidence levels
     omega_diag = np.array([
-        base_uncertainty[i] * (1 - conf) / conf 
+        base_uncertainty[i] * (1 - conf) / conf
         for i, conf in enumerate(confidences)
     ])
-    
+
     # Create diagonal Omega matrix
     omega = np.diag(omega_diag)
-    
+
     return omega
 ```
 
@@ -243,7 +255,7 @@ def calibrate_omega(P, cov_matrix, tau, confidences):
 def black_litterman(pi, P, Q, tau, omega, cov_matrix):
     """
     Calculate Black-Litterman expected returns.
-    
+
     Parameters:
     -----------
     pi : ndarray
@@ -258,7 +270,7 @@ def black_litterman(pi, P, Q, tau, omega, cov_matrix):
         View uncertainty matrix
     cov_matrix : ndarray
         Covariance matrix of returns
-        
+
     Returns:
     --------
     ndarray
@@ -268,14 +280,14 @@ def black_litterman(pi, P, Q, tau, omega, cov_matrix):
     precision_prior = np.linalg.inv(tau * cov_matrix)
     precision_views = P.T @ np.linalg.inv(omega) @ P
     precision_posterior = precision_prior + precision_views
-    
+
     # Calculate posterior mean
     mean_component1 = precision_prior @ pi
     mean_component2 = P.T @ np.linalg.inv(omega) @ Q
-    
+
     # Posterior mean = M * [precision_prior * pi + P' * omega^-1 * Q]
     bl_returns = np.linalg.inv(precision_posterior) @ (mean_component1 + mean_component2)
-    
+
     return bl_returns
 ```
 
@@ -285,7 +297,7 @@ def black_litterman(pi, P, Q, tau, omega, cov_matrix):
 def optimize_portfolio(expected_returns, cov_matrix, risk_aversion, constraints=None):
     """
     Optimize portfolio weights given expected returns and constraints.
-    
+
     Parameters:
     -----------
     expected_returns : ndarray
@@ -296,33 +308,33 @@ def optimize_portfolio(expected_returns, cov_matrix, risk_aversion, constraints=
         Risk aversion parameter
     constraints : dict, optional
         Portfolio constraints
-        
+
     Returns:
     --------
     ndarray
         Optimal portfolio weights
     """
     n_assets = len(expected_returns)
-    
+
     # Define objective function (maximize utility)
     def objective(weights):
         portfolio_return = weights @ expected_returns
         portfolio_variance = weights @ cov_matrix @ weights
         utility = portfolio_return - 0.5 * risk_aversion * portfolio_variance
         return -utility  # Negate for minimization
-    
+
     # Initial weights (equal weight)
     initial_weights = np.ones(n_assets) / n_assets
-    
+
     # Basic constraints
     bounds = [(0, 1) for _ in range(n_assets)]  # Long-only constraint
     weight_constraint = {'type': 'eq', 'fun': lambda x: np.sum(x) - 1}  # Sum to 1
-    
+
     # Add custom constraints if provided
     all_constraints = [weight_constraint]
     if constraints:
         all_constraints.extend(constraints)
-    
+
     # Optimize
     result = minimize(
         objective,
@@ -331,7 +343,7 @@ def optimize_portfolio(expected_returns, cov_matrix, risk_aversion, constraints=
         bounds=bounds,
         constraints=all_constraints
     )
-    
+
     if result.success:
         return result.x
     else:
@@ -345,6 +357,7 @@ def optimize_portfolio(expected_returns, cov_matrix, risk_aversion, constraints=
 To address numerical instability in matrix operations:
 
 1. **Cholesky Decomposition**: Use Cholesky decomposition for matrix inversion
+
    ```python
    def stable_inverse(matrix):
        """Stable matrix inversion using Cholesky decomposition."""
@@ -354,6 +367,7 @@ To address numerical instability in matrix operations:
    ```
 
 2. **Covariance Regularization**: Apply shrinkage to the covariance matrix
+
    ```python
    def shrink_covariance(sample_cov, shrinkage=0.1):
        """Apply shrinkage to sample covariance matrix."""
@@ -386,26 +400,28 @@ For consistent numerical behavior:
 For factor-based implementation:
 
 1. **Factor Returns Equilibrium**:
+
    ```python
    # Calculate factor equilibrium returns
    B = factor_exposures  # Asset-factor exposure matrix
    w_mkt = market_weights
    Σ_F = factor_covariance
-   
+
    # Factor implied returns
    π_F = λ * Σ_F @ B.T @ w_mkt
    ```
 
 2. **Factor-Based Views**:
+
    ```python
    # Express views on factors instead of assets
    P_F = factor_view_matrix
    Q_F = factor_view_values
    Ω_F = factor_view_uncertainty
-   
+
    # Factor Black-Litterman
    μ_F_BL = black_litterman(π_F, P_F, Q_F, τ, Ω_F, Σ_F)
-   
+
    # Convert to asset expected returns
    μ_BL = B @ μ_F_BL + α
    ```
@@ -435,7 +451,8 @@ VeritasVault provides these implementation components:
 7. **Visualization Suite**: Tools for visualizing inputs, outputs, and sensitivities
 
 For more detailed information on specific aspects, see:
-* [Black-Litterman Overview](./black-litterman-overview.md)
-* [Black-Litterman Model](./black-litterman-model.md)
-* [Black-Litterman Views](./black-litterman-views.md)
-* [Black-Litterman Validation](./black-litterman-validation.md)
+
+- [Black-Litterman Overview](./black-litterman-overview.md)
+- [Black-Litterman Model](./black-litterman-model.md)
+- [Black-Litterman Views](./black-litterman-views.md)
+- [Black-Litterman Validation](./black-litterman-validation.md)

--- a/src/vv.Domain/Docs/Domains/Asset/portfolio-management/black-litterman/black-litterman-model.md
+++ b/src/vv.Domain/Docs/Domains/Asset/portfolio-management/black-litterman/black-litterman-model.md
@@ -3,16 +3,16 @@ document_type: guide
 classification: internal
 status: draft
 version: 0.1.0
-last_updated: '2025-05-31'
+last_updated: "2025-05-31"
 applies_to:
-- Core
+  - Core
 reviewers:
-- '@tech-lead'
+  - "@tech-lead"
 priority: p2
-next_review: '2026-05-31'
+next_review: "2026-05-31"
 ---
 
-```src/vv.Domain/Docs/Domains/Asset/black-litterman-model.md
+````src/vv.Domain/Docs/Domains/Asset/black-litterman-model.md
 # Black-Litterman Model
 
 > Mathematical formulation of the Black-Litterman approach
@@ -152,14 +152,24 @@ Where $T$ is the effective number of observations used to estimate $\Sigma$.
 
 ### View Uncertainty (Ω)
 
+> **ERRATA — see ADR-0001 §D1**
+> (`docs/adr/0001-black-litterman-model-conventions.md`, repository root).
+> **Option 2 below is withdrawn.** At $c_i = 1$ it leaves $\Omega \neq 0$, so the
+> view does not bind and $P\mu_{BL} \neq Q$ — contradicting the sanity check in
+> [black-litterman-validation.md](./black-litterman-validation.md) §Verification
+> Techniques, item 2. The confidence-bearing form adopted for implementation is
+> the one in [black-litterman-implementation.md](./black-litterman-implementation.md)
+> `calibrate_omega`: $\Omega_{ii} = (P(\tau\Sigma)P^T)_{ii}\cdot(1-c_i)/c_i$.
+> Option 1 remains correct and is the implementation default.
+
 Several approaches exist for calibrating $\Omega$:
 
 1. **Proportional to Prior Variance**:
    $$\Omega = \text{diag}(P(\tau\Sigma)P^T)$$
 
-2. **Confidence-Based**:
+2. **Confidence-Based** *(withdrawn — see errata above)*:
    $$\Omega_{ii} = \frac{1}{c_i} (P\Sigma P^T)_{ii}$$
-   
+
    Where $c_i$ is the confidence in view $i$, scaled from 0 to 1.
 
 3. **Historical Method**:
@@ -170,6 +180,21 @@ Several approaches exist for calibrating $\Omega$:
 The optimal portfolio weights using the Black-Litterman expected returns are:
 
 $$w_{BL} = (\lambda\Sigma)^{-1}\mu_{BL}$$
+
+> **ERRATA — see ADR-0001 §D2**
+> (`docs/adr/0001-black-litterman-model-conventions.md`, repository root).
+> The risk matrix in this expression is an explicit implementation choice, not a
+> given. Using $\Sigma$ (as written above) is the implementation default and is
+> the only choice under which the equilibrium round-trip $w_{BL} = w_{mkt}$ holds
+> exactly. He & Litterman use the posterior $\Sigma_p = \Sigma + M$, under which
+> the round-trip holds up to a factor $1/(1+\tau)$. Golden-vector fixtures must
+> state which convention they assume — most failures to reproduce published
+> results are convention mismatches rather than arithmetic errors.
+>
+> Note also that $\mu_{BL}$ is **invariant to $\tau$** under both implemented
+> default $\Omega$ calibrations, because $\Omega \propto \tau$ makes $\tau$
+> cancel in the expression above. $M \propto \tau$, so the posterior covariance
+> is not invariant.
 
 ## Practical Considerations
 
@@ -223,23 +248,24 @@ from scipy import linalg
 def black_litterman(Sigma, w_mkt, P, Q, tau=0.025, lambda_=2.5, Omega=None):
     # Calculate implied returns
     Pi = lambda_ * Sigma @ w_mkt
-    
+
     # Set default Omega if not provided
     if Omega is None:
         Omega = np.diag(np.diag(tau * P @ Sigma @ P.T))
-    
+
     # Calculate posterior distribution parameters
     M = np.linalg.inv(np.linalg.inv(tau * Sigma) + P.T @ np.linalg.inv(Omega) @ P)
     mu_BL = M @ (np.linalg.inv(tau * Sigma) @ Pi + P.T @ np.linalg.inv(Omega) @ Q)
-    
+
     # Calculate optimal weights
     w_BL = np.linalg.inv(lambda_ * Sigma) @ mu_BL
-    
+
     return mu_BL, w_BL
-```
+````
 
 For further details on specific aspects of the model, see:
-* [Black-Litterman Overview](./black-litterman-overview.md)
-* [Black-Litterman Views](./black-litterman-views.md)
-* [Black-Litterman Implementation](./black-litterman-implementation.md)
-* [Black-Litterman Validation](./black-litterman-validation.md)
+
+- [Black-Litterman Overview](./black-litterman-overview.md)
+- [Black-Litterman Views](./black-litterman-views.md)
+- [Black-Litterman Implementation](./black-litterman-implementation.md)
+- [Black-Litterman Validation](./black-litterman-validation.md)

--- a/src/vv.Domain/Docs/Domains/Asset/portfolio-management/black-litterman/black-litterman-views.md
+++ b/src/vv.Domain/Docs/Domains/Asset/portfolio-management/black-litterman/black-litterman-views.md
@@ -3,13 +3,13 @@ document_type: guide
 classification: internal
 status: draft
 version: 0.1.0
-last_updated: '2025-05-31'
+last_updated: "2025-05-31"
 applies_to:
-- Core
+  - Core
 reviewers:
-- '@tech-lead'
+  - "@tech-lead"
 priority: p2
-next_review: '2026-05-31'
+next_review: "2026-05-31"
 ---
 
 ```src/vv.Domain/Docs/Domains/Asset/black-litterman-views.md
@@ -148,6 +148,17 @@ For consistent confidence scaling:
    * $\Omega_{ii} = (P\Sigma P^T)_{ii} \times \frac{1-c_i}{c_i}$
    * Where $c_i \in (0,1]$ is confidence percentage
 
+> **ERRATA — see ADR-0001 §D1**
+> (`docs/adr/0001-black-litterman-model-conventions.md`, repository root).
+> The implemented form includes $\tau$:
+> $\Omega_{ii} = (P(\tau\Sigma)P^T)_{ii}\times\frac{1-c_i}{c_i}$, matching
+> `calibrate_omega` in [black-litterman-implementation.md](./black-litterman-implementation.md).
+> Endpoint handling is defined rather than left to the formula: $c_i = 0$ **drops
+> the view's row from $P$ and $Q$** (exactly equivalent to the $\Omega\to\infty$
+> limit, and numerically clean where clamping is not), and $c_i = 1$ gives
+> $\Omega_{ii} = 0$, which is well-posed only in the covariance form of the
+> posterior, not the precision form.
+
 ## Multiple View Management
 
 ### Consistency Checking
@@ -246,3 +257,4 @@ For more detailed information on specific aspects, see:
 * [Black-Litterman Model](./black-litterman-model.md)
 * [Black-Litterman Implementation](./black-litterman-implementation.md)
 * [Black-Litterman Validation](./black-litterman-validation.md)
+```


### PR DESCRIPTION
## What this is

A complete specification for the Black-Litterman engine — which is **positioned across all three investor decks and does not exist** — plus the alternative allocation models and the verification framework needed to tell whether any of them actually work.

**No solver code.** The engine remains unimplemented, and the decks correctly say so. Nothing here may be cited as evidence otherwise; the honesty gate in the plan defines exactly when that changes.

## Why it grew past "implement BL"

Three findings drove the scope:

1. **The specification contradicts itself.** Three different Ω formulas appear across four documents. `black-litterman-model.md:161` is provably wrong — at 100% confidence it leaves Ω ≠ 0 so views never bind, contradicting the sanity check in `black-litterman-validation.md`. Six result DTO fields have no definition anywhere in the 45 documents. Building before resolving these means the golden vectors get chosen to match whatever was built.

2. **.NET has no maintained QP solver.** Accord is archived at 3.8.0, OR-Tools' continuous side is LP, alglib's free edition is GPL. The C# route required hand-rolling Goldfarb–Idnani. Rust's `nalgebra` + `clarabel` are both Apache-2.0 and remove the need entirely.

3. **Nothing in the original plan could tell you whether BL was helping.** BL is 1992 textbook material with three open-source implementations — legibility, not IP. The defensible work is auditability and comparison, so the deliverable became a comparison harness with BL as one model in it.

## Contents

| File | |
|---|---|
| `docs/black-litterman-implementation-plan.md` | 11 sections, sequenced build order, ~70 test IDs, honesty gate |
| `docs/adr/0001` | Model conventions — **needs domain sign-off**, D2 is the one to argue about |
| `docs/adr/0002` | Rust numeric core via P/Invoke |
| `docs/adr/0003` | Comparison harness; marks BL `novelty: commodity` |
| `docs/adr/0004` | Three-stage abstraction — **must be accepted before Phase 1** |
| `docs/specs/allocation-models.md` | Contracts and invariants for nine models |
| `docs/specs/model-verification.md` | Tier A correctness, Tier B validity, meta-verification |

Errata added in place to three specification documents so the withdrawn Ω formula is not implemented from the spec tree.

## Things worth a reviewer's attention

- **ADR-0001 D2** (Σ vs Σ_p as the optimizer risk matrix) is a genuine modelling judgement and the decision most likely to be overturned. Structured as a flippable default plus a golden re-baseline.
- **ADR-0004 gates Phase 1.** Retrofitting the three-stage split after BL is built means rewriting BL.
- **Sample-size honesty**: twelve monthly observations cannot distinguish a Sharpe of 1.0 from 0.5 — that needs ~17 years. The claims ledger therefore has **no state that can assert one model outperforms another**, because the data will never support it.
- Cross-platform bit-determinism is treated as a *correctness constraint*, not hygiene, because `BlackLitterman-Reference.md:22` requires signed auditable output and a one-ULP difference breaks signature verification.

## Separately found, not fixed here

- `scripts/coverage-report.js` references `vvPlatform.sln`; the file is `vv.Platform.sln`. The post-commit hook fails on every commit as a result.
- `.github/workflows/link-check-config.json` sets `projectBaseUrl` to `VeritasVault-ai/vv`; this remote is `JustAGhosT/veritasvault`.
- `tests/vv.Application.Tests` has no csproj, is not in the solution, and its two files no longer compile against current source.
- 19 git-tracked paths across the case-variant `AI/FinancialModels` and `AI/financial-models` trees; all nine pairs are byte-identical, so deduplication is lossless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
