### PR TITLE
ci: grant pull-requests write to the build workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,14 @@ on:
     branches: [main, master, develop]
   workflow_dispatch:
 
+# The repository moved into the neuralliquid org, where the default
+# GITHUB_TOKEN permission is read-only. The coverage-comment step needs
+# pull-requests: write, so grant it explicitly here rather than relying on
+# an org-wide default.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     name: Build and Test


### PR DESCRIPTION
**Every PR in this repo is currently blocked.** This is a one-line-ish fix that unblocks them.

## Symptom

`Build and Test` fails on its last step, `Add Coverage PR Comment`:

```text
##[error]Request failed due to following response errors:
 - Resource not accessible by integration
```

Every substantive step passes — restore, build, test with coverage, coverage threshold, upload. Only the comment post fails. Because `Build and Test` is a **required** status check on `main`, this puts affected PRs in `mergeStateStatus: BLOCKED`.

## Cause

The repository moved into the `neuralliquid` org. That org's `default_workflow_permissions` is **`read`**:

```console
$ gh api orgs/neuralliquid/actions/permissions/workflow
default_workflow_permissions=read
```

`build-and-test.yml` declared no `permissions:` block, so it inherited that default. `marocchino/sticky-pull-request-comment` needs `pull-requests: write`.

Under the previous personal-account owner the default was `write`, which is why this passed until the transfer and failed immediately after — the last green run on another branch was 80 seconds before the first red one, which brackets the change closely.

## Fix

An explicit workflow-level grant:

```yaml
permissions:
  contents: read
  pull-requests: write
```

Chosen over flipping `default_workflow_permissions` to `write` for the org: this scopes the write grant to the one workflow that needs it, instead of making every token in every repo writable by default. `contents: read` is stated explicitly because naming any permission drops the rest to none.

This PR's own run exercises the fix, so a green check here *is* the verification.

## Note for #31

[PR #31](https://github.com/neuralliquid/veritasvault/pull/31) also edits `build-and-test.yml`. This change is a self-contained insertion between `on:` and `jobs:`, so it should merge cleanly either way, but whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
